### PR TITLE
feat: error widget

### DIFF
--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -4,6 +4,7 @@ import "package:go_router/go_router.dart";
 
 import "../features/dashboard/dashboard_page.dart";
 import "../features/debug_playground/debug_playground.dart";
+import "../features/error/error_page.dart";
 import "../features/home/home_page.dart";
 import "../features/info/info_page.dart";
 import "../features/others/others_page.dart";

--- a/lib/app/config/ui_config.dart
+++ b/lib/app/config/ui_config.dart
@@ -166,3 +166,8 @@ abstract final class InfoSectionConfig {
   static const creatorTileWidth = 190.0;
   static const creatorTileHeight = 280.0;
 }
+
+abstract final class ErrorWidgetConfig {
+  static const iconSize = 80.0;
+  static const buttonOutsidePadding = 60.0;
+}

--- a/lib/app/l10n/arb/app_pl.arb
+++ b/lib/app/l10n/arb/app_pl.arb
@@ -37,5 +37,10 @@
 
   "info_follow_us": "Zaobserwuj nas!",
   "info_creators": "Creators",
-  "info_more_info": "Więcej o wydarzeniu!"
+  "info_more_info": "Więcej o wydarzeniu!",
+
+  "errors_back": "Wróć do głównej",
+  "errors_title": "Przepraszamy, wystąpił błąd",
+  "errors_generic":  "Coś poszło nie tak",
+  "errors_launch": "Wystąpił błąd podczas otwierania adresu"
 }

--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -35,6 +35,14 @@ final _router = GoRouter(
         ),
       ],
     ),
+    GoRoute(
+      path: ErrorPage.routeName,
+      parentNavigatorKey: _rootNavigatorKey,
+      builder: (context, state) {
+        final message = state.uri.queryParameters["message"];
+        return ErrorPage(message: message, onBackToHome: () => context.router.goHome());
+      },
+    ),
     if (kDebugMode)
       GoRoute(
         path: DebugPlayground.routeName,
@@ -52,6 +60,10 @@ extension RouterX on GoRouter {
   void goHome() => go(HomePage.routeName);
   Future<void> pushRouteMap(int id) async => push("${RouteMapPage.routeName}/$id");
   Future<void> pushPlayground() async => push(DebugPlayground.routeName);
+  Future<void> pushFullScreenError(String message) async {
+    debugPrint(message);
+    await push("${ErrorPage.routeName}?message=${Uri.encodeComponent(message)}");
+  }
 }
 
 //temp

--- a/lib/common/utils/url_launcher.dart
+++ b/lib/common/utils/url_launcher.dart
@@ -1,10 +1,10 @@
 import "package:url_launcher/url_launcher.dart";
 
-Future<void> customLaunchUrl(String url) async {
+Future<void> customLaunchUrl(String url, String errorMessage) async {
   final uri = Uri.parse(url);
   if (await canLaunchUrl(uri)) {
     await launchUrl(uri);
   } else {
-    throw Exception("Could not launch $url");
+    throw Exception("$errorMessage: \n$url");
   }
 }

--- a/lib/features/debug_playground/debug_playground.dart
+++ b/lib/features/debug_playground/debug_playground.dart
@@ -27,6 +27,10 @@ class DebugPlayground extends StatelessWidget {
                   ),
               child: const Text("Route Completed Modal"),
             ),
+            OutlinedButton(
+              onPressed: () async => context.router.pushFullScreenError("Oto testowy error. lorem ipsum i tak dalej"),
+              child: const Text("Error Page"),
+            ),
             const TestProviderWidget(),
           ],
         ),

--- a/lib/features/error/error_page.dart
+++ b/lib/features/error/error_page.dart
@@ -1,0 +1,20 @@
+import "package:flutter/material.dart";
+import "../../app/theme/app_theme.dart";
+import "views/full_screen_error_view.dart";
+
+class ErrorPage extends StatelessWidget {
+  static const routeName = "/fullScreenError";
+
+  final String? message;
+  final VoidCallback onBackToHome;
+
+  const ErrorPage({super.key, this.message, required this.onBackToHome});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: context.colorScheme.surface,
+      body: FullScreenErrorView(message: message, onBackToHome: onBackToHome),
+    );
+  }
+}

--- a/lib/features/error/views/full_screen_error_view.dart
+++ b/lib/features/error/views/full_screen_error_view.dart
@@ -1,0 +1,41 @@
+import "package:flutter/material.dart";
+
+import "../../../app/config/ui_config.dart";
+import "../../../app/l10n/l10n.dart";
+import "../../../app/theme/app_theme.dart";
+import "../../../common/widgets/main_action_button.dart";
+
+class FullScreenErrorView extends StatelessWidget {
+  final String? message;
+  final VoidCallback onBackToHome;
+
+  const FullScreenErrorView({super.key, this.message, required this.onBackToHome});
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(AppPaddings.medium),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.error, size: ErrorWidgetConfig.iconSize, color: context.colorScheme.error),
+            const SizedBox(height: AppPaddings.small),
+            Text(context.l10n.errors_title, style: context.textTheme.headlineMedium),
+            const SizedBox(height: AppPaddings.small),
+            Text(
+              message ?? context.l10n.errors_generic,
+              style: context.textTheme.bodyMedium,
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: AppPaddings.medium),
+            Padding(
+              padding: const EdgeInsetsGeometry.symmetric(horizontal: ErrorWidgetConfig.buttonOutsidePadding),
+              child: MainActionButton(onPressed: onBackToHome, text: context.l10n.errors_back),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/info/views/info_view.dart
+++ b/lib/features/info/views/info_view.dart
@@ -1,6 +1,7 @@
 import "package:fast_immutable_collections/fast_immutable_collections.dart";
 import "package:flutter/material.dart";
 
+import "../../../app/app.dart";
 import "../../../app/config/ui_config.dart";
 import "../../../app/l10n/l10n.dart";
 import "../../../common/models/creator.dart";
@@ -38,13 +39,28 @@ class InfoView extends StatelessWidget {
   }
 }
 
-class InfoSectionWidget extends StatelessWidget {
+class InfoSectionWidget extends StatefulWidget {
   const InfoSectionWidget({super.key, required this.infoSection});
 
   final InfoSection infoSection;
 
   @override
+  State<InfoSectionWidget> createState() => _InfoSectionWidgetState();
+}
+
+class _InfoSectionWidgetState extends State<InfoSectionWidget> {
+  Future<void> _tryLaunchUrl(String url) async {
+    try {
+      await customLaunchUrl(url, context.l10n.errors_launch);
+    } on Exception catch (e) {
+      if (!mounted) return;
+      await context.router.pushFullScreenError(e.toString());
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
+    final infoSection = widget.infoSection;
     return ListView(
       shrinkWrap: true,
       physics: const NeverScrollableScrollPhysics(),
@@ -66,7 +82,7 @@ class InfoSectionWidget extends StatelessWidget {
                         (infoSection.socials != null && infoSection.socials!.onlyWeb)
                             ? MainActionButton(
                               text: context.l10n.info_more_info,
-                              onPressed: () async => customLaunchUrl(infoSection.socials!.webUrl!),
+                              onPressed: () => _tryLaunchUrl(infoSection.socials!.webUrl!),
                             )
                             : SocialsSection(compact: false, socials: infoSection.socials!),
                   )

--- a/lib/features/info/widgets/social_icon_button.dart
+++ b/lib/features/info/widgets/social_icon_button.dart
@@ -1,0 +1,32 @@
+import "package:flutter/material.dart";
+import "package:flutter_svg/svg.dart";
+
+import "../../../app/app.dart";
+import "../../../app/l10n/l10n.dart";
+import "../../../common/utils/url_launcher.dart";
+
+class SocialIconButton extends StatefulWidget {
+  const SocialIconButton({super.key, required this.icon, required this.url});
+
+  final SvgPicture icon;
+  final String url;
+
+  @override
+  State<SocialIconButton> createState() => _SocialIconButtonState();
+}
+
+class _SocialIconButtonState extends State<SocialIconButton> {
+  @override
+  Widget build(BuildContext context) {
+    return IconButton(icon: widget.icon, onPressed: _tryLaunchUrl);
+  }
+
+  Future<void> _tryLaunchUrl() async {
+    try {
+      await customLaunchUrl(widget.url, context.l10n.errors_launch);
+    } on Exception catch (e) {
+      if (!mounted) return;
+      await context.router.pushFullScreenError(e.toString());
+    }
+  }
+}

--- a/lib/features/info/widgets/socials_section.dart
+++ b/lib/features/info/widgets/socials_section.dart
@@ -5,7 +5,7 @@ import "../../../app/config/ui_config.dart";
 import "../../../app/l10n/l10n.dart";
 import "../../../app/theme/app_theme.dart";
 import "../../../common/models/socials.dart";
-import "../../../common/utils/url_launcher.dart";
+import "social_icon_button.dart";
 
 class SocialsSection extends StatelessWidget {
   const SocialsSection({super.key, required this.socials, this.compact = true});
@@ -36,18 +36,6 @@ class SocialsSection extends StatelessWidget {
         ),
       ],
     );
-  }
-}
-
-class SocialIconButton extends StatelessWidget {
-  const SocialIconButton({super.key, required this.icon, required this.url});
-
-  final SvgPicture icon;
-  final String url;
-
-  @override
-  Widget build(BuildContext context) {
-    return IconButton(icon: icon, onPressed: () async => customLaunchUrl(url));
   }
 }
 


### PR DESCRIPTION
Added an error page that always appears on top of the others and redirects user to home upon pressing a button, an error view to style the page, new route and push function to trigger the page in the goRouter. The widgets catching errors ??had to be converted to stateful?? because they utilised the context and for dart using context in an async function is a no-no, because widgets can get destroyed before the context is used.

Also, an issue to look into: 'ł' is not displaying properly when using bodyMedium, headlineMedium, or in fact any other textTheme:
<img width="422" alt="image" src="https://github.com/user-attachments/assets/0a453fae-851b-4109-8e28-bdd0082ed3d1" />
<img width="452" alt="image" src="https://github.com/user-attachments/assets/889e26d2-d8e6-4e04-8c55-9d61e8067e5b" />
