### PR TITLE
refactor: route map widget

### DIFF
--- a/lib/features/debug_playground/debug_playground.dart
+++ b/lib/features/debug_playground/debug_playground.dart
@@ -2,6 +2,7 @@ import "package:flutter/material.dart";
 import "package:flutter_riverpod/flutter_riverpod.dart";
 
 import "../../app/app.dart";
+import "../route_map/controllers/route_controller.dart";
 import "../route_map/repository/route_map_repository.dart";
 import "../route_map/widgets/modals/route_completed_modal.dart";
 
@@ -31,6 +32,7 @@ class DebugPlayground extends StatelessWidget {
               onPressed: () async => context.router.pushFullScreenError("Oto testowy error. lorem ipsum i tak dalej"),
               child: const Text("Error Page"),
             ),
+
             const TestProviderWidget(),
           ],
         ),
@@ -47,9 +49,22 @@ class TestProviderWidget extends ConsumerWidget {
     final routes = ref.watch(fetchAllRoutesProvider);
     final route_2 = ref.watch(fetchRouteWithIdProvider(2));
 
+    final count = ref.watch(visitedCountProvider);
     return Column(
       mainAxisAlignment: MainAxisAlignment.center,
       children: <Widget>[
+        OutlinedButton(
+          onPressed: () {
+            ref.read(visitedCountProvider.notifier).incrementVisited();
+          },
+          child: Text("Visit Next Landmark, current: $count"),
+        ),
+        OutlinedButton(
+          onPressed: () {
+            ref.read(visitedCountProvider.notifier).resetVisited();
+          },
+          child: const Text("Reset"),
+        ),
         routes.when(
           data: (routes) => Text("Routes:\n$routes"),
           loading: CircularProgressIndicator.new,

--- a/lib/features/route_map/controllers/route_controller.dart
+++ b/lib/features/route_map/controllers/route_controller.dart
@@ -65,3 +65,19 @@ class Speed extends _$Speed {
     return (distance / time.inSeconds) * 3.6; // distance in km/h
   }
 }
+
+@riverpod
+class VisitedCount extends _$VisitedCount {
+  @override
+  int build() {
+    return 1;
+  }
+
+  void incrementVisited() {
+    state = state + 1;
+  }
+
+  void resetVisited() {
+    state = 1;
+  }
+}

--- a/lib/features/route_map/controllers/route_controller.dart
+++ b/lib/features/route_map/controllers/route_controller.dart
@@ -1,5 +1,9 @@
 import "dart:async";
+import "package:fast_immutable_collections/fast_immutable_collections.dart";
+import "package:latlong2/latlong.dart";
 import "package:riverpod_annotation/riverpod_annotation.dart";
+
+import "../../../common/models/landmark.dart";
 
 part "route_controller.g.dart";
 
@@ -80,4 +84,18 @@ class VisitedCount extends _$VisitedCount {
   void resetVisited() {
     state = 1;
   }
+}
+
+bool latLngEqual(LatLng a, LatLng b, {double tolerance = 0.0003}) {
+  return (a.latitude - b.latitude).abs() < tolerance && (a.longitude - b.longitude).abs() < tolerance;
+}
+
+int calculateLineChangeFromLandmarksLatLng({
+  required IList<Landmark> landmarks,
+  required IList<LatLng> route,
+  required int visited,
+}) {
+  final index = visited.clamp(1, landmarks.length) - 1;
+  final target = landmarks[index].location;
+  return route.indexWhere((point) => latLngEqual(point, target)) + 1;
 }

--- a/lib/features/route_map/views/route_map_view.dart
+++ b/lib/features/route_map/views/route_map_view.dart
@@ -57,8 +57,8 @@ class RouteMapViewState extends ConsumerState<RouteMapView> {
     return Scaffold(
       body: Stack(
         children: [
-          RouteMapWidget(route: widget.route, visitedCount: 3, active: _currentSheetState == SheetState.hidden),
-          RouteProgressBar(landmarks: widget.route.landmarks, visitedCount: 3),
+          RouteMapWidget(route: widget.route, active: _currentSheetState == SheetState.hidden),
+          RouteProgressBar(landmarks: widget.route.landmarks),
           MapBottomSheet(
             button: MainActionButton(
               text: context.l10n.end_route,

--- a/lib/features/route_map/widgets/progress_bar/route_progress_bar.dart
+++ b/lib/features/route_map/widgets/progress_bar/route_progress_bar.dart
@@ -17,10 +17,10 @@ class RouteProgressBar extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final total = landmarks.length;
-    final visitedCount = ref.watch(visitedCountProvider);
-    final visited = visitedCount.clamp(0, total);
-
     if (total <= 1) return const SizedBox();
+
+    final visitedCount = ref.watch(visitedCountProvider);
+    final visited = visitedCount.clamp(1, total);
 
     return Align(
       alignment: Alignment.topCenter,

--- a/lib/features/route_map/widgets/progress_bar/route_progress_bar.dart
+++ b/lib/features/route_map/widgets/progress_bar/route_progress_bar.dart
@@ -1,63 +1,64 @@
 import "package:fast_immutable_collections/fast_immutable_collections.dart";
 import "package:flutter/material.dart";
+import "package:flutter_riverpod/flutter_riverpod.dart";
+
 import "../../../../app/config/ui_config.dart";
 import "../../../../app/theme/app_theme.dart";
 import "../../../../common/models/landmark.dart";
+import "../../controllers/route_controller.dart";
 import "route_progress_bar_icon.dart";
 import "route_progress_bar_line.dart";
 
-class RouteProgressBar extends StatefulWidget {
+class RouteProgressBar extends ConsumerWidget {
   final IList<Landmark> landmarks;
-  final int visitedCount;
 
-  const RouteProgressBar({super.key, required this.landmarks, required this.visitedCount});
+  const RouteProgressBar({super.key, required this.landmarks});
 
   @override
-  State<RouteProgressBar> createState() => _RouteProgressBarState();
-}
+  Widget build(BuildContext context, WidgetRef ref) {
+    final total = landmarks.length;
+    final visitedCount = ref.watch(visitedCountProvider);
+    final visited = visitedCount.clamp(0, total);
 
-class _RouteProgressBarState extends State<RouteProgressBar> {
-  @override
-  Widget build(BuildContext context) {
-    final total = widget.landmarks.length;
-    final visited = widget.visitedCount.clamp(0, total);
+    if (total <= 1) return const SizedBox();
 
-    return total <= 1
-        ? const SizedBox()
-        : Align(
-          alignment: Alignment.topCenter,
-          child: Container(
-            decoration: _decoration(context.colorScheme.surface),
-            width: double.infinity,
-            padding: const EdgeInsets.only(top: ProgressBarConfig.topPadding, bottom: AppPaddings.tinySmall),
-            child: SafeArea(
-              bottom: false,
-              child: Padding(
-                padding: const EdgeInsets.symmetric(horizontal: ProgressBarConfig.horizontalPadding),
-                child: Row(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: List.generate(widget.landmarks.length * 2 - 1, (i) {
-                    if (i.isEven) {
-                      final index = i ~/ 2;
-                      final visited = index < widget.visitedCount;
-                      if (index == 0) {
-                        return RouteProgressBarIcon(start: true, done: true, color: context.colorScheme.primary);
-                      }
-                      if (index == total - 1) {
-                        return RouteProgressBarIcon(finish: true, done: visited, color: context.colorScheme.primary);
-                      }
-                      return RouteProgressBarIcon(done: visited, color: context.colorScheme.primary);
-                    } else {
-                      final lineIndex = (i - 1) ~/ 2;
-                      final isVisited = lineIndex < visited - 1;
-                      return RouteProgressBarLine(color: context.colorScheme.primary, done: isVisited);
-                    }
-                  }),
-                ),
-              ),
+    return Align(
+      alignment: Alignment.topCenter,
+      child: Container(
+        decoration: _decoration(context.colorScheme.surface),
+        width: double.infinity,
+        padding: const EdgeInsets.only(top: ProgressBarConfig.topPadding, bottom: AppPaddings.tinySmall),
+        child: SafeArea(
+          bottom: false,
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: ProgressBarConfig.horizontalPadding),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: List.generate(landmarks.length * 2 - 1, (i) {
+                if (i.isEven) {
+                  final index = i ~/ 2;
+                  final isVisited = index < visitedCount;
+
+                  if (index == 0) {
+                    return RouteProgressBarIcon(start: true, done: true, color: context.colorScheme.primary);
+                  }
+
+                  if (index == total - 1) {
+                    return RouteProgressBarIcon(finish: true, done: isVisited, color: context.colorScheme.primary);
+                  }
+
+                  return RouteProgressBarIcon(done: isVisited, color: context.colorScheme.primary);
+                } else {
+                  final lineIndex = (i - 1) ~/ 2;
+                  final isVisited = lineIndex < visited - 1;
+                  return RouteProgressBarLine(color: context.colorScheme.primary, done: isVisited);
+                }
+              }),
             ),
           ),
-        );
+        ),
+      ),
+    );
   }
 }
 


### PR DESCRIPTION
This PR changes how the visited count is obtained by the map widget and the progress bar widget: the visitedCount is no longer being passed in by the map view but rather obtained from a provider in both widgets. Because the route is not a straight line between landmarks but a path containing many coordinates, I was not sure how to handle obtaining the index of the line switch (from visited green to the unvisited dashed gray). For now I decided that the path between landmarks should be either fully gray or fully green and that the progress should update once the user passes the landmark; this can be changed into having a line cutoff coordinates provider and coloring the line based on its state. As I mentioned, I am unsure what the desired behaviour and end result truly is, this is merely my interpretation.

I added two buttons in the debug playground to change the number of visited landmarks and be able to verify the result on the map.

<img width="364" alt="image" src="https://github.com/user-attachments/assets/8eaf28ff-5f73-490a-a44c-4636d4cc473a" />
<img width="376" alt="image" src="https://github.com/user-attachments/assets/45a6e732-9f18-459b-97a5-21b12bb6b120" />
<img width="363" alt="image" src="https://github.com/user-attachments/assets/38c51cad-1ec3-4363-a54d-1e9cbf4b46df" />


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor map and progress bar widgets to use a provider for visited landmarks count, simplifying state management.
> 
>   - **Behavior**:
>     - `visitedCount` is now obtained from `visitedCountProvider` in `RouteMapWidget` and `RouteProgressBar`, removing the need to pass it as a parameter.
>     - Path between landmarks is either fully gray or fully green; progress updates after passing a landmark.
>     - Adds buttons in `debug_playground.dart` to increment and reset visited landmarks for testing.
>   - **Functions**:
>     - Adds `VisitedCount` provider in `route_controller.dart` with methods `incrementVisited()` and `resetVisited()`.
>     - Introduces `calculateLineChangeFromLandmarksLatLng()` in `route_controller.dart` to determine line change index.
>   - **Widgets**:
>     - `RouteMapWidget` and `RouteProgressBar` updated to use `visitedCountProvider`.
>     - `RouteProgressBar` refactored to a `ConsumerWidget` to access providers directly.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fmobile-umed&utm_source=github&utm_medium=referral)<sup> for 26f5a888db9dc8e4a984a70fa12ba0964209f257. You can [customize](https://app.ellipsis.dev/Solvro/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->