### PR TITLE
fix: hide bottom sheet when user taps on map

### DIFF
--- a/lib/features/route_map/views/route_map_view.dart
+++ b/lib/features/route_map/views/route_map_view.dart
@@ -72,6 +72,18 @@ class RouteMapViewState extends ConsumerState<RouteMapView> {
               AsyncLoading() => const CircularProgressIndicator(),
               _ => Center(child: Text(context.l10n.errors_generic)),
             },
+            Positioned.fill(
+              child: IgnorePointer(
+                ignoring: _currentSheetState == SheetState.hidden,
+                child: Listener(
+                  behavior: HitTestBehavior.translucent,
+                  onPointerDown: (_) {
+                    ref.read(sheetStateProvider.notifier).state = SheetState.hidden;
+                    ref.read(sheetTriggerProvider.notifier).state = true;
+                  },
+                ),
+              ),
+            ),
             SelectRouteBottomSheet(),
           ],
         ),
@@ -81,6 +93,18 @@ class RouteMapViewState extends ConsumerState<RouteMapView> {
       body: Stack(
         children: [
           RouteMapWidget(route: route, active: _currentSheetState == SheetState.hidden),
+          Positioned.fill(
+            child: IgnorePointer(
+              ignoring: _currentSheetState == SheetState.hidden,
+              child: Listener(
+                behavior: HitTestBehavior.translucent,
+                onPointerDown: (_) {
+                  ref.read(sheetStateProvider.notifier).state = SheetState.hidden;
+                  ref.read(sheetTriggerProvider.notifier).state = true;
+                },
+              ),
+            ),
+          ),
           RouteProgressBar(landmarks: route.landmarks),
           const RouteBottomSheet(),
           Positioned(


### PR DESCRIPTION
Previously, when bottom sheet was open and user taped on the map, the map was interacted with but the sheet would not hide. This was fixed, so that now when the user taps on the map, the sheet automatically hides. 

https://github.com/user-attachments/assets/ef77290a-53a5-40bf-9b5b-675b58b04988


