### PR TITLE
fix: paddings in listView

### DIFF
--- a/lib/common/widgets/common/horizontal_routes_list/horizontal_routes_list.dart
+++ b/lib/common/widgets/common/horizontal_routes_list/horizontal_routes_list.dart
@@ -18,32 +18,30 @@ class RouteListWidget extends StatelessWidget {
     required this.icon,
     this.height = RouteListConfig.height,
     this.itemWidth = RouteListConfig.itemWidth,
-    this.sideMargin = RouteListConfig.defaultSideMargin,
+    this.sideMargin = AppPaddings.medium,
     super.key,
   });
 
   @override
   Widget build(BuildContext context) {
-    return Padding(
-      padding: EdgeInsets.symmetric(horizontal: sideMargin),
-      child: SizedBox(
-        height: height,
-        child: ListView.separated(
-          scrollDirection: Axis.horizontal,
-          itemCount: routes.length,
-          separatorBuilder: (_, __) => const SizedBox(width: AppPaddings.tinySmall),
-          itemBuilder: (_, index) {
-            final route = routes[index];
-            return RouteCard(
-              key: ValueKey(route.id),
-              route: route,
-              onTap: () => onRouteTap(route),
-              width: itemWidth,
-              height: height,
-              icon: icon,
-            );
-          },
-        ),
+    return SizedBox(
+      height: height,
+      child: ListView.separated(
+        padding: EdgeInsets.symmetric(horizontal: sideMargin),
+        scrollDirection: Axis.horizontal,
+        itemCount: routes.length,
+        separatorBuilder: (_, __) => const SizedBox(width: AppPaddings.tinySmall),
+        itemBuilder: (_, index) {
+          final route = routes[index];
+          return RouteCard(
+            key: ValueKey(route.id),
+            route: route,
+            onTap: () => onRouteTap(route),
+            width: itemWidth,
+            height: height,
+            icon: icon,
+          );
+        },
       ),
     );
   }

--- a/lib/features/home/views/home_view.dart
+++ b/lib/features/home/views/home_view.dart
@@ -25,19 +25,13 @@ class HomeView extends StatelessWidget {
       ),
       body: ListView(
         physics: const AlwaysScrollableScrollPhysics(),
-        padding: const EdgeInsets.only(
-          top: AppPaddings.tinySmall,
-          left: AppPaddings.tinySmall,
-          right: AppPaddings.tinySmall,
-          bottom: AppPaddings.veryLarge,
-        ),
+        padding: const EdgeInsets.only(top: AppPaddings.tinySmall, bottom: AppPaddings.veryLarge),
         children: [
           const SizedBox(height: AppPaddings.tinySmall),
           SectionHeader(context.l10n.home_nearest_to_you),
           RouteListWidget(
             routes: routes,
             onRouteTap: (route) => context.router.pushRouteMap(id: route.id),
-            sideMargin: HomeViewConfig.sideMargin,
             icon: Icons.arrow_forward_ios,
           ),
           const SizedBox(height: HomeViewConfig.commonGap),

--- a/lib/features/home/widgets/button_row.dart
+++ b/lib/features/home/widgets/button_row.dart
@@ -11,7 +11,7 @@ class HomeButtonsRow extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: HomeViewConfig.sideMargin),
+      padding: const EdgeInsets.symmetric(horizontal: AppPaddings.medium),
       child: SizedBox(
         height: VerticalButtonConfig.cardMinimumHeight,
         child: Row(

--- a/lib/features/home/widgets/start_route_button.dart
+++ b/lib/features/home/widgets/start_route_button.dart
@@ -9,7 +9,7 @@ class StartRouteButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: HomeViewConfig.sideMargin),
+      padding: const EdgeInsets.symmetric(horizontal: AppPaddings.medium),
       child: ElevatedButton(
         style: sharedCardButtonStyle(context),
         onPressed: context.router.pushRouteMap,

--- a/lib/features/profile/views/profile_view.dart
+++ b/lib/features/profile/views/profile_view.dart
@@ -29,23 +29,17 @@ class ProfileView extends ConsumerWidget {
       ),
       body: SingleChildScrollView(
         physics: const AlwaysScrollableScrollPhysics(),
-        padding: const EdgeInsets.only(
-          top: AppPaddings.tinySmall,
-          left: AppPaddings.tinySmall,
-          right: AppPaddings.tinySmall,
-          bottom: AppPaddings.veryLarge,
-        ),
+        padding: const EdgeInsets.only(top: AppPaddings.tinySmall, bottom: AppPaddings.veryLarge),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             const SizedBox(height: AppPaddings.medium),
             SectionHeader(context.l10n.common_finished_routes),
-            const ProgressBar(progress: 0.67123),
+            const ProgressBar(progress: 0.67123), // TODO(tomasz-trela): replace with real progress
             const SizedBox(height: AppPaddings.tiny),
             RouteListWidget(
               routes: routes,
               onRouteTap: (route) => context.router.pushRouteMap(id: route.id),
-              sideMargin: ProfileViewConfig.sideMargin,
               icon: Icons.autorenew,
             ),
             const SizedBox(height: AppPaddings.medium),

--- a/lib/features/profile/widgets/horizontal_stat_card_list/horizontal_card_list.dart
+++ b/lib/features/profile/widgets/horizontal_stat_card_list/horizontal_card_list.dart
@@ -15,28 +15,26 @@ class StatListWidget extends StatelessWidget {
     required this.stats,
     this.height = CardListConfig.height,
     this.itemWidth = CardListConfig.itemWidth,
-    this.sideMargin = CardListConfig.defaultSideMargin,
+    this.sideMargin = AppPaddings.medium,
     this.iconSize = CardListConfig.iconSize,
   });
 
   @override
   Widget build(BuildContext context) {
-    return Padding(
-      padding: EdgeInsets.symmetric(horizontal: sideMargin),
-      child: SizedBox(
-        height: height,
-        child: ListView.separated(
-          scrollDirection: Axis.horizontal,
-          itemCount: stats.length,
-          separatorBuilder: (_, __) => const SizedBox(width: AppPaddings.tinySmall),
-          itemBuilder: (_, index) {
-            final stat = stats[index];
-            return Padding(
-              padding: const EdgeInsets.only(bottom: AppPaddings.nano),
-              child: StatCard(stat: stat, iconSize: iconSize, width: itemWidth, height: height),
-            );
-          },
-        ),
+    return SizedBox(
+      height: height,
+      child: ListView.separated(
+        padding: EdgeInsets.symmetric(horizontal: sideMargin),
+        scrollDirection: Axis.horizontal,
+        itemCount: stats.length,
+        separatorBuilder: (_, __) => const SizedBox(width: AppPaddings.tinySmall),
+        itemBuilder: (_, index) {
+          final stat = stats[index];
+          return Padding(
+            padding: const EdgeInsets.only(bottom: AppPaddings.nano),
+            child: StatCard(stat: stat, iconSize: iconSize, width: itemWidth, height: height),
+          );
+        },
       ),
     );
   }


### PR DESCRIPTION
#109 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Standardized padding across widgets by using `AppPaddings.medium` and simplified code by removing redundant padding parameters.
> 
>   - **Padding Adjustments**:
>     - `RouteListWidget` in `horizontal_routes_list.dart`: Moved padding from `Padding` widget to `ListView.separated`.
>     - `StatListWidget` in `horizontal_card_list.dart`: Moved padding from `Padding` widget to `ListView.separated`.
>     - `HomeView` in `home_view.dart`: Simplified padding to only top and bottom.
>     - `HomeButtonsRow` in `button_row.dart` and `StartRouteButton` in `start_route_button.dart`: Changed horizontal padding to `AppPaddings.medium`.
>   - **Code Simplification**:
>     - Removed `sideMargin` parameter from `RouteListWidget` and `StatListWidget` constructors in `home_view.dart` and `profile_view.dart`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fmobile-umed&utm_source=github&utm_medium=referral)<sup> for 0c3689fb331f18430254980b6aca731b0a95679f. You can [customize](https://app.ellipsis.dev/Solvro/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->