### PR TITLE
feat: ask before exiting route using phone's navigation

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -59,15 +59,15 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
-  flutter_foreground_task: 21ef182ab0a29a3005cc72cd70e5f45cb7f7f817
-  flutter_rotation_sensor: f37d8d24050572029bdd2d55a93e0f334e2eeac6
-  geolocator_apple: 66b711889fd333205763b83c9dcf0a57a28c7afd
-  native_device_orientation: 348b10c346a60ebbc62fb235a4fdb5d1b61a8f55
-  package_info_plus: c0502532a26c7662a62a356cebe2692ec5fe4ec4
-  path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
-  shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78
-  sqflite_darwin: 5a7236e3b501866c1c9befc6771dfd73ffb8702d
-  url_launcher_ios: 5334b05cef931de560670eeae103fd3e431ac3fe
+  flutter_foreground_task: a159d2c2173b33699ddb3e6c2a067045d7cebb89
+  flutter_rotation_sensor: bf55ead3f64f27207dacc5972fe8ebe932f3de0b
+  geolocator_apple: ab36aa0e8b7d7a2d7639b3b4e48308394e8cef5e
+  native_device_orientation: e3580675687d5034770da198f6839ebf2122ef94
+  package_info_plus: af8e2ca6888548050f16fa2f1938db7b5a5df499
+  path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
+  shared_preferences_foundation: 9e1978ff2562383bd5676f64ec4e9aa8fa06a6f7
+  sqflite_darwin: 20b2a3a3b70e43edae938624ce550a3cbf66a3d0
+  url_launcher_ios: 694010445543906933d732453a59da0a173ae33d
 
 PODFILE CHECKSUM: 4305caec6b40dde0ae97be1573c53de1882a07e5
 

--- a/lib/common/utils/modal_before_exiting.dart
+++ b/lib/common/utils/modal_before_exiting.dart
@@ -1,0 +1,28 @@
+import "package:flutter/material.dart";
+import "package:go_router/go_router.dart";
+
+class ModalBeforeExiting extends StatelessWidget {
+  const ModalBeforeExiting({required this.modal, required this.child});
+
+  final Widget modal;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return PopScope(
+      canPop: false,
+      onPopInvokedWithResult: (bool didPop, Object? result) async {
+        if (didPop) {
+          return;
+        }
+        final bool shouldPop = await showDialog<bool>(context: context, builder: (context) => modal) ?? false;
+        if (context.mounted && shouldPop) {
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            if (context.mounted) context.pop();
+          });
+        }
+      },
+      child: child,
+    );
+  }
+}

--- a/lib/features/route_map/modals/end_route_modal.dart
+++ b/lib/features/route_map/modals/end_route_modal.dart
@@ -1,4 +1,5 @@
 import "package:flutter/material.dart";
+import "../../../app/app.dart";
 import "../../../app/config/ui_config.dart";
 import "../../../app/l10n/l10n.dart";
 import "../../../app/theme/app_theme.dart";
@@ -17,13 +18,13 @@ class EndRouteModal extends StatelessWidget {
         backgroundColor: context.colorScheme.error,
         text: context.l10n.end_route,
         onPressed: () {
-          Navigator.of(context).pop(true);
+          context.router.pop(true);
         },
       ),
       cancelButton: MainActionButton(
         text: context.l10n.keep_going,
         onPressed: () {
-          Navigator.of(context).pop(false);
+          context.router.pop(false);
         },
       ),
       child: Column(

--- a/lib/features/route_map/modals/end_route_modal.dart
+++ b/lib/features/route_map/modals/end_route_modal.dart
@@ -1,6 +1,4 @@
 import "package:flutter/material.dart";
-
-import "../../../app/app.dart";
 import "../../../app/config/ui_config.dart";
 import "../../../app/l10n/l10n.dart";
 import "../../../app/theme/app_theme.dart";
@@ -19,11 +17,15 @@ class EndRouteModal extends StatelessWidget {
         backgroundColor: context.colorScheme.error,
         text: context.l10n.end_route,
         onPressed: () {
-          context.router.pop();
-          context.router.pop();
+          Navigator.of(context).pop(true);
         },
       ),
-      cancelButton: MainActionButton(text: context.l10n.keep_going, onPressed: context.router.pop),
+      cancelButton: MainActionButton(
+        text: context.l10n.keep_going,
+        onPressed: () {
+          Navigator.of(context).pop(false);
+        },
+      ),
       child: Column(
         children: [
           Text(context.l10n.route_end_modal_helper, textAlign: TextAlign.start, overflow: TextOverflow.fade),

--- a/lib/features/route_map/views/route_map_view.dart
+++ b/lib/features/route_map/views/route_map_view.dart
@@ -6,6 +6,8 @@ import "../../../app/l10n/l10n.dart";
 import "../../../app/theme/app_theme.dart";
 import "../../../common/providers/bottom_sheet_providers.dart";
 import "../../../common/utils/location_service.dart";
+import "../../../common/utils/modal_before_exiting.dart";
+import "../modals/end_route_modal.dart";
 import "../providers/route_provider.dart";
 import "../repository/route_map_repository.dart";
 import "../widgets/bottom_sheet/route_bottom_sheet.dart";
@@ -34,9 +36,15 @@ class RouteMapViewState extends ConsumerState<RouteMapView> with TickerProviderS
     _currentSheetState = ref.read(sheetStateProvider);
   }
 
+  @override
+  void dispose() {
+    _mapController.dispose();
+    super.dispose();
+  }
+
   Future<void> _centerToUserLocation() async {
     final latLng = await LocationService.getCurrentLatLng();
-    if (latLng == null) return;
+    if (latLng == null || !mounted) return;
     await _mapController.animateTo(
       dest: latLng,
       zoom: 14,
@@ -87,19 +95,22 @@ class RouteMapViewState extends ConsumerState<RouteMapView> with TickerProviderS
       );
     }
 
-    return Scaffold(
-      body: Stack(
-        children: [
-          RouteMapWidget(controller: _mapController, route: route, active: _currentSheetState == SheetState.hidden),
-          _SheetHidingHitTest(currentSheetState: _currentSheetState),
-          RouteProgressBar(checkpoints: route.checkpoints),
-          const RouteBottomSheet(),
-          Positioned(
-            top: 106,
-            right: 12,
-            child: FloatingActionButton.small(onPressed: _centerToUserLocation, child: const Icon(Icons.my_location)),
-          ),
-        ],
+    return ModalBeforeExiting(
+      modal: const EndRouteModal(),
+      child: Scaffold(
+        body: Stack(
+          children: [
+            RouteMapWidget(controller: _mapController, route: route, active: _currentSheetState == SheetState.hidden),
+            _SheetHidingHitTest(currentSheetState: _currentSheetState),
+            RouteProgressBar(checkpoints: route.checkpoints),
+            const RouteBottomSheet(),
+            Positioned(
+              top: 106,
+              right: 12,
+              child: FloatingActionButton.small(onPressed: _centerToUserLocation, child: const Icon(Icons.my_location)),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/features/route_map/widgets/bottom_sheet/route_bottom_sheet.dart
+++ b/lib/features/route_map/widgets/bottom_sheet/route_bottom_sheet.dart
@@ -2,7 +2,7 @@ import "dart:async";
 
 import "package:flutter/material.dart";
 import "package:flutter_riverpod/flutter_riverpod.dart";
-
+import "package:go_router/go_router.dart";
 import "../../../../app/config/ui_config.dart";
 import "../../../../app/l10n/l10n.dart";
 import "../../../../app/theme/app_theme.dart";
@@ -46,7 +46,11 @@ class RouteBottomSheetState extends ConsumerState<RouteBottomSheet> {
         backgroundColor: context.colorScheme.error,
         onPressed: () async {
           ref.read(sheetTriggerProvider.notifier).state = true;
-          await showDialog<EndRouteModal>(context: context, builder: (context) => const EndRouteModal());
+          final bool shouldPop =
+              await showDialog<bool>(context: context, builder: (context) => const EndRouteModal()) ?? false;
+          if (context.mounted && shouldPop) {
+            context.pop();
+          }
         },
       ),
       controls: Row(

--- a/lib/features/route_map/widgets/map/route_map_widget.dart
+++ b/lib/features/route_map/widgets/map/route_map_widget.dart
@@ -1,6 +1,5 @@
 import "dart:async";
 import "dart:io";
-
 import "package:fast_immutable_collections/fast_immutable_collections.dart";
 import "package:flutter/material.dart" hide Route;
 import "package:flutter_foreground_task/flutter_foreground_task.dart";
@@ -9,7 +8,6 @@ import "package:flutter_map_animations/flutter_map_animations.dart";
 import "package:flutter_map_location_marker/flutter_map_location_marker.dart";
 import "package:flutter_riverpod/flutter_riverpod.dart";
 import "package:latlong2/latlong.dart";
-
 import "../../../../app/config/flutter_map_config.dart";
 import "../../../../app/config/ui_config.dart";
 import "../../../../app/theme/app_theme.dart";
@@ -102,12 +100,6 @@ class RouteMapWidgetState extends ConsumerState<RouteMapWidget> with WidgetsBind
     if (state == AppLifecycleState.resumed) {
       await LocationService.requestPermissions();
     }
-  }
-
-  @override
-  void dispose() {
-    widget.controller.dispose();
-    super.dispose();
   }
 
   @override


### PR DESCRIPTION
Now the modal asking if the user is sure about exiting pops up both when ending the route with a button and using navigation. When no route is chosen, the RouteMapView doesn't show the additional prompt.

Note: moved the disposal of the mapController to the parent widget - RouteMapView instead of RouteMapWidget, because a) the parent creating the controller should manage its lifecycle and b) the current setting caused errors when used with PopScope - I'm unsure why the error only started occurring now, but it was caused by the improper usage and disposal of the mapController

https://github.com/user-attachments/assets/dfe0e133-aab2-4eb6-8698-013ddfa70d5e


<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds a modal confirmation for exiting routes and refactors map controller lifecycle management in `RouteMapView`.
> 
>   - **Behavior**:
>     - Adds `ModalBeforeExiting` in `modal_before_exiting.dart` to prompt user confirmation before exiting a route.
>     - Integrates `ModalBeforeExiting` in `RouteMapView` to handle both button and navigation exits.
>     - Updates `EndRouteModal` in `end_route_modal.dart` to return boolean on user action.
>   - **Lifecycle Management**:
>     - Moves `_mapController` disposal from `RouteMapWidget` to `RouteMapView` to manage lifecycle correctly.
>   - **Misc**:
>     - Updates `Podfile.lock` checksums for dependencies.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fmobile-umed&utm_source=github&utm_medium=referral)<sup> for d2aef96ed78b12d91cccadddfa2c600cfbd03d44. You can [customize](https://app.ellipsis.dev/Solvro/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->