### PR TITLE
fix: change start and finish logic to be based on enum type

### DIFF
--- a/lib/features/route_map/widgets/map/route_map_marker.dart
+++ b/lib/features/route_map/widgets/map/route_map_marker.dart
@@ -29,16 +29,16 @@ class RouteMapMarker extends StatelessWidget {
     late final bool isTextMarker;
     final orderValue = order?.toString() ?? "";
 
-    (icon, isTextMarker) = switch ((start, finish, type, active, visited)) {
-      (true, _, _, true, _) => (Assets.icons.startActive.svg(), false),
-      (true, _, _, false, _) => (Assets.icons.startInactive.svg(), false),
-      (_, true, _, true, _) => (Assets.icons.finishActive.svg(), false),
-      (_, true, _, false, _) => (Assets.icons.finishInactive.svg(), false),
-      (_, _, LandmarkType.pulsometer, true, true) => (Assets.icons.pulsometerVisited.svg(), false),
-      (_, _, LandmarkType.pulsometer, true, false) => (Assets.icons.pulsometerUnvisited.svg(), false),
-      (_, _, LandmarkType.pulsometer, false, _) => (Assets.icons.pulsometerInactive.svg(), false),
-      (_, _, LandmarkType.checkpoint, true, true) => (Assets.icons.checkpointVisited.svg(), true),
-      (_, _, LandmarkType.checkpoint, true, false) => (Assets.icons.checkpointUnvisited.svg(), true),
+    (icon, isTextMarker) = switch ((type, active, visited)) {
+      (LandmarkType.start, true, _) => (Assets.icons.startActive.svg(), false),
+      (LandmarkType.start, false, _) => (Assets.icons.startInactive.svg(), false),
+      (LandmarkType.finish, true, _) => (Assets.icons.finishActive.svg(), false),
+      (LandmarkType.finish, false, _) => (Assets.icons.finishInactive.svg(), false),
+      (LandmarkType.pulsometer, true, true) => (Assets.icons.pulsometerVisited.svg(), false),
+      (LandmarkType.pulsometer, true, false) => (Assets.icons.pulsometerUnvisited.svg(), false),
+      (LandmarkType.pulsometer, false, _) => (Assets.icons.pulsometerInactive.svg(), false),
+      (LandmarkType.checkpoint, true, true) => (Assets.icons.checkpointVisited.svg(), true),
+      (LandmarkType.checkpoint, true, false) => (Assets.icons.checkpointUnvisited.svg(), true),
       _ => (Assets.icons.checkpointInactive.svg(), true),
     };
 

--- a/lib/features/route_map/widgets/map/route_map_marker.dart
+++ b/lib/features/route_map/widgets/map/route_map_marker.dart
@@ -6,20 +6,10 @@ import "../../../../app/config/ui_config.dart";
 import "../../../../common/models/checkpoint.dart";
 
 class RouteMapMarker extends StatelessWidget {
-  const RouteMapMarker({
-    super.key,
-    required this.type,
-    required this.active,
-    this.start = false,
-    this.finish = false,
-    this.visited = false,
-    this.order,
-  });
+  const RouteMapMarker({super.key, required this.type, required this.active, this.visited = false, this.order});
 
   final LandmarkType type;
   final bool active;
-  final bool start;
-  final bool finish;
   final bool visited;
   final int? order;
 

--- a/lib/features/route_map/widgets/map/route_map_widget.dart
+++ b/lib/features/route_map/widgets/map/route_map_widget.dart
@@ -209,14 +209,7 @@ class RouteMapWidgetState extends ConsumerState<RouteMapWidget> with WidgetsBind
                   builder: (_) => LandmarkInfoModal(checkpoint: landmark),
                 )
                 : null,
-        child: RouteMapMarker(
-          type: landmark.type,
-          active: active,
-          start: index == 0,
-          finish: index == totalLandmarks - 1,
-          visited: visitedCount - 1 >= index,
-          order: index,
-        ),
+        child: RouteMapMarker(type: landmark.type, active: active, visited: visitedCount - 1 >= index, order: index),
       ),
     );
   }


### PR DESCRIPTION
Marker icons on the map are now selected based on the checkpoint enum type (start, finish, checkpoint, pulsometer) instead of the checkpoint order or start/finish flags. This makes the logic consistent with the new data model and improves maintainability.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Marker icons are now selected based on `LandmarkType` enum in `RouteMapMarker`, removing `start` and `finish` flags.
> 
>   - **Behavior**:
>     - Marker icons in `RouteMapMarker` are now selected based on `LandmarkType` enum instead of `start`, `finish` flags or `order`.
>     - Affects logic in `RouteMapWidget` where `RouteMapMarker` is instantiated.
>   - **Code Changes**:
>     - Removed `start` and `finish` parameters from `RouteMapMarker` constructor.
>     - Updated switch case in `RouteMapMarker.build()` to use `LandmarkType` enum.
>     - Simplified marker instantiation in `RouteMapWidgetState._buildMarkers()` by removing `start` and `finish` logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fmobile-umed&utm_source=github&utm_medium=referral)<sup> for 3bed3ce0d85462c2f9814e399f676443c538080b. You can [customize](https://app.ellipsis.dev/Solvro/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->