### PR TITLE
refactor: show only expanded routes on map

### DIFF
--- a/lib/features/route_map/providers/route_provider.dart
+++ b/lib/features/route_map/providers/route_provider.dart
@@ -1,9 +1,9 @@
+import "dart:collection";
 import "package:flutter_riverpod/flutter_riverpod.dart";
-
 import "../../../common/models/route.dart";
 
 enum RouteDetailsOption { info, playlist }
 
 final routeProvider = StateProvider<Route?>((ref) => null);
 
-final selectedRoutesProvider = StateProvider<List<Route>>((ref) => []);
+final expandedRoutesProvider = StateProvider<LinkedHashSet<Route>>((ref) => LinkedHashSet());

--- a/lib/features/route_map/route_map_page.dart
+++ b/lib/features/route_map/route_map_page.dart
@@ -1,6 +1,6 @@
+import "dart:collection";
 import "package:flutter/material.dart" hide Route;
 import "package:flutter_riverpod/flutter_riverpod.dart";
-
 import "../../app/app.dart";
 import "../../common/models/route.dart";
 import "../../common/providers/bottom_sheet_providers.dart";
@@ -22,7 +22,7 @@ class RouteMapPage extends ConsumerWidget {
     ref.read(sheetStateProvider.notifier).state = SheetState.hidden;
     ref.read(passedLocationsProvider.notifier).state = 0;
     ref.read(visitedCountProvider.notifier).resetVisited();
-    ref.read(selectedRoutesProvider.notifier).state = [];
+    ref.read(expandedRoutesProvider.notifier).state = LinkedHashSet();
   }
 
   @override

--- a/lib/features/route_map/views/route_map_view.dart
+++ b/lib/features/route_map/views/route_map_view.dart
@@ -80,10 +80,9 @@ class RouteMapViewState extends ConsumerState<RouteMapView> with TickerProviderS
         body: Stack(
           children: [
             switch (allRoutesAsync) {
-              AsyncData(:final value) => RouteMapWidget(
+              AsyncData() => RouteMapWidget(
                 controller: _mapController,
                 active: _currentSheetState == SheetState.hidden,
-                optionalRoutes: value,
               ),
               AsyncLoading() => const CircularProgressIndicator(),
               _ => Center(child: Text(context.l10n.errors_generic)),

--- a/lib/features/route_map/widgets/bottom_sheet/tiles/route_tile.dart
+++ b/lib/features/route_map/widgets/bottom_sheet/tiles/route_tile.dart
@@ -1,6 +1,6 @@
+import "dart:collection";
 import "package:flutter/material.dart" hide Route;
 import "package:flutter_riverpod/flutter_riverpod.dart";
-
 import "../../../../../app/assets/assets.gen.dart";
 import "../../../../../app/config/ui_config.dart";
 import "../../../../../app/l10n/l10n.dart";
@@ -33,20 +33,22 @@ class RouteTileState extends ConsumerState<RouteTile> {
     _chosenOption = RouteDetailsOption.info;
   }
 
+  void updateExpandedRoutes(Route route, {bool shouldDelete = false}) {
+    final currentSelectedRoutes = ref.read(expandedRoutesProvider);
+    final updatedRoutes = LinkedHashSet<Route>.from(currentSelectedRoutes);
+    updatedRoutes.remove(route);
+    if (!shouldDelete) {
+      updatedRoutes.add(route);
+    }
+    ref.read(expandedRoutesProvider.notifier).state = updatedRoutes;
+  }
+
   @override
   Widget build(BuildContext context) {
     final route = widget.route;
 
     return ExpansionTile(
-      onExpansionChanged: (isExpanding) {
-        final currentSelectedRoutes = ref.read(selectedRoutesProvider);
-        if (isExpanding) {
-          ref.read(selectedRoutesProvider.notifier).state = [...currentSelectedRoutes, route];
-        } else {
-          ref.read(selectedRoutesProvider.notifier).state =
-              currentSelectedRoutes.where((routeElement) => routeElement != route).toList();
-        }
-      },
+      onExpansionChanged: (isExpanding) => updateExpandedRoutes(route, shouldDelete: !isExpanding),
       title: Row(
         spacing: AppPaddings.nano,
         children: [
@@ -95,6 +97,7 @@ class RouteTileState extends ConsumerState<RouteTile> {
               Expanded(
                 child: SecondaryActionButton(
                   onPressed: () {
+                    updateExpandedRoutes(route);
                     setState(() => _chosenOption = RouteDetailsOption.info);
                   },
                   text: context.l10n.route_description,
@@ -106,6 +109,7 @@ class RouteTileState extends ConsumerState<RouteTile> {
               Expanded(
                 child: SecondaryActionButton(
                   onPressed: () {
+                    updateExpandedRoutes(route);
                     setState(() => _chosenOption = RouteDetailsOption.playlist);
                   },
                   text: context.l10n.playlist,

--- a/lib/features/route_map/widgets/map/route_map_widget.dart
+++ b/lib/features/route_map/widgets/map/route_map_widget.dart
@@ -29,11 +29,10 @@ import "route_selections_polyline.dart";
 const distance = Distance();
 
 class RouteMapWidget extends ConsumerStatefulWidget {
-  const RouteMapWidget({super.key, required this.controller, this.route, this.optionalRoutes, this.active = true});
+  const RouteMapWidget({super.key, required this.controller, this.route, this.active = true});
 
   final AnimatedMapController controller;
   final Route? route;
-  final IList<Route>? optionalRoutes;
   final bool active;
 
   @override
@@ -107,7 +106,7 @@ class RouteMapWidgetState extends ConsumerState<RouteMapWidget> with WidgetsBind
     final route = widget.route;
     final tileProvider = ref.watch(cacheTileProvider);
     final visitedCount = ref.watch(visitedCountProvider);
-    final selectedRoutes = ref.watch(selectedRoutesProvider);
+    final expandedRoutes = ref.watch(expandedRoutesProvider);
     final passedLocations = ref.watch(passedLocationsProvider);
     final landmarks = route?.checkpoints ?? const IListConst([]);
 
@@ -119,12 +118,13 @@ class RouteMapWidgetState extends ConsumerState<RouteMapWidget> with WidgetsBind
               mapController: widget.controller.mapController,
               children: [
                 TileLayer(urlTemplate: FlutterMapConfig.urlTemplate, maxZoom: 19),
-                RouteSelectionsPolyline(
-                  locations: (widget.optionalRoutes?.asList() ?? []).map((r) => r.route).toIList(),
-                  selected: selectedRoutes.isNotEmpty ? selectedRoutes.last : null,
-                  selectedColor: context.colorScheme.primary,
-                  notSelectedColor: MapConfig.unvisitedColor,
-                ),
+                if (expandedRoutes.isNotEmpty)
+                  RouteSelectionsPolyline(
+                    locations: expandedRoutes.asList().map((r) => r.route).toIList(),
+                    lastInteracted: expandedRoutes.last,
+                    selectedColor: context.colorScheme.primary,
+                    notSelectedColor: MapConfig.unvisitedColor,
+                  ),
               ],
             )
             : FlutterMap(

--- a/lib/features/route_map/widgets/map/route_selections_polyline.dart
+++ b/lib/features/route_map/widgets/map/route_selections_polyline.dart
@@ -9,12 +9,12 @@ class RouteSelectionsPolyline extends StatelessWidget {
   const RouteSelectionsPolyline({
     super.key,
     required this.locations,
-    this.selected,
+    this.lastInteracted,
     required this.selectedColor,
     required this.notSelectedColor,
   });
   final IList<IList<LatLng>> locations;
-  final Route? selected;
+  final Route? lastInteracted;
   final Color selectedColor;
   final Color notSelectedColor;
 
@@ -28,8 +28,12 @@ class RouteSelectionsPolyline extends StatelessWidget {
           (element) =>
               Polyline(points: element.toList(), color: notSelectedColor, strokeWidth: MapConfig.unvisitedLineWidth),
         ),
-        if (selected != null)
-          Polyline(points: selected!.route.toList(), color: selectedColor, strokeWidth: MapConfig.visitedLineWidth),
+        if (lastInteracted != null)
+          Polyline(
+            points: lastInteracted!.route.toList(),
+            color: selectedColor,
+            strokeWidth: MapConfig.visitedLineWidth,
+          ),
       ],
     );
   }


### PR DESCRIPTION

https://github.com/user-attachments/assets/12dcafbb-5683-4ef9-8fd2-92ce0a20295a

Now only expanded routes are visible in gray on the map. Last interacted route is always highlighted in green.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor route map to display only expanded routes in gray and highlight last interacted route in green.
> 
>   - **Behavior**:
>     - Only expanded routes are shown in gray on the map; last interacted route is highlighted in green.
>     - `RouteSelectionsPolyline` in `route_selections_polyline.dart` updated to use `lastInteracted` route for highlighting.
>   - **Providers**:
>     - Renamed `selectedRoutesProvider` to `expandedRoutesProvider` in `route_provider.dart`.
>     - `expandedRoutesProvider` now uses `LinkedHashSet` to maintain order of routes.
>   - **Widgets**:
>     - `RouteMapWidget` in `route_map_widget.dart` updated to use `expandedRoutesProvider` for displaying routes.
>     - `RouteTile` in `route_tile.dart` updated to manage expanded routes using `updateExpandedRoutes()` function.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fmobile-umed&utm_source=github&utm_medium=referral)<sup> for d9f1ef10924535aa821e41cd4f31d5520a0fb061. You can [customize](https://app.ellipsis.dev/Solvro/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->