### PR TITLE
fix: cached image null error

### DIFF
--- a/lib/common/widgets/common/horizontal_routes_list/route_card.dart
+++ b/lib/common/widgets/common/horizontal_routes_list/route_card.dart
@@ -38,7 +38,9 @@ class RouteCard extends StatelessWidget {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
-              Expanded(child: CachedImage("${Env.apiUrl}assets/${route.image}")),
+              Expanded(
+                child: CachedImage((route.image?.isNotEmpty ?? false) ? "${Env.apiUrl}assets/${route.image}" : null),
+              ),
               Container(
                 color: colorScheme.primary,
                 padding: const EdgeInsets.all(AppPaddings.tinySmall),


### PR DESCRIPTION
Bugfix

When creating a route card with a route without an image, the url from which the image was fetched was: baseUrl/assets/null, which in turn caused an error to be silently thrown. 

<img width="340" height="121" alt="image" src="https://github.com/user-attachments/assets/5198bc5c-6f71-471a-9d3d-36d70444dda3" />

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes null error in `RouteCard` by checking if `route.image` is not empty before constructing the image URL.
> 
>   - **Bugfix**:
>     - Fixes null error in `RouteCard` in `route_card.dart` by checking if `route.image` is not empty before constructing the image URL.
>     - If `route.image` is empty or null, `CachedImage` is passed `null` instead of a malformed URL.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fmobile-umed&utm_source=github&utm_medium=referral)<sup> for 79f2ccdd1b33924f17d4764e54ea0ff8bee80fec. You can [customize](https://app.ellipsis.dev/Solvro/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->