### PR TITLE
fix: change icon completed routes

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -17,7 +17,7 @@ PODS:
     - Flutter
     - FlutterMacOS
   - Sentry/HybridSDK (8.52.1)
-  - sentry_flutter (9.5.0):
+  - sentry_flutter (9.6.0):
     - Flutter
     - FlutterMacOS
     - Sentry/HybridSDK (= 8.52.1)
@@ -84,7 +84,7 @@ SPEC CHECKSUMS:
   package_info_plus: af8e2ca6888548050f16fa2f1938db7b5a5df499
   path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
   Sentry: 2cbbe3592f30050c60e916c63c7f5a2fa584005e
-  sentry_flutter: fcd61ad26b7890479c182deff29f1f0714319b52
+  sentry_flutter: 9b1e3e6934cb7040ffb71383c95a35f73523180c
   shared_preferences_foundation: 9e1978ff2562383bd5676f64ec4e9aa8fa06a6f7
   sqflite_darwin: 20b2a3a3b70e43edae938624ce550a3cbf66a3d0
   url_launcher_ios: 694010445543906933d732453a59da0a173ae33d

--- a/lib/app/config/ui_config.dart
+++ b/lib/app/config/ui_config.dart
@@ -175,6 +175,11 @@ abstract final class VerticalButtonConfig {
   static const double greenHeader = 60;
 }
 
+abstract final class CircularProgressConfig {
+  static const double strokeWidth = 10;
+  static const double backgroundAlpha = 0.2;
+}
+
 abstract final class RouteListConfig {
   static const double height = 225;
   static const double itemWidth = 180;

--- a/lib/app/config/ui_config.dart
+++ b/lib/app/config/ui_config.dart
@@ -178,6 +178,18 @@ abstract final class VerticalButtonConfig {
 abstract final class CircularProgressConfig {
   static const double strokeWidth = 10;
   static const double backgroundAlpha = 0.2;
+
+  static LinearGradient createProgressGradient(ColorScheme colorScheme) {
+    return LinearGradient(
+      colors: [colorScheme.primary, colorScheme.secondary, colorScheme.error],
+      begin: Alignment.topLeft,
+      end: Alignment.bottomRight,
+    );
+  }
+
+  static TextStyle? createProgressTextStyle(ColorScheme colorScheme, TextStyle? baseTextStyle) {
+    return baseTextStyle?.copyWith(color: colorScheme.primary, fontWeight: FontWeight.bold);
+  }
 }
 
 abstract final class RouteListConfig {

--- a/lib/app/config/ui_config.dart
+++ b/lib/app/config/ui_config.dart
@@ -179,11 +179,11 @@ abstract final class CircularProgressConfig {
   static const double strokeWidth = 10;
   static const double backgroundAlpha = 0.2;
 
-  static LinearGradient createProgressGradient(ColorScheme colorScheme) {
-    return LinearGradient(
-      colors: [colorScheme.primary, colorScheme.secondary, colorScheme.error],
-      begin: Alignment.topLeft,
-      end: Alignment.bottomRight,
+  static SweepGradient createProgressGradient(ColorScheme colorScheme) {
+    return SweepGradient(
+      colors: [colorScheme.error, colorScheme.error, colorScheme.primary, colorScheme.primary, colorScheme.error],
+      stops: const [0.0, 0.25, 0.5, 0.75, 1.0],
+      endAngle: 2 * 3.14159,
     );
   }
 

--- a/lib/common/providers/progress_provider.dart
+++ b/lib/common/providers/progress_provider.dart
@@ -1,0 +1,16 @@
+import "package:flutter_riverpod/flutter_riverpod.dart";
+import "package:riverpod_annotation/riverpod_annotation.dart";
+import "../../../features/route_map/repository/route_map_repository.dart";
+import "completed_routes_provider.dart";
+
+part "progress_provider.g.dart";
+
+@riverpod
+Future<double> routeProgress(Ref ref) async {
+  final routes = await ref.watch(fetchAllRoutesProvider.future);
+  final completedRoutes = await ref.watch(completedRoutesProvider.future);
+
+  if (routes.isEmpty) return 0.0;
+
+  return completedRoutes.length / routes.length;
+}

--- a/lib/common/widgets/buttons/vertical_button.dart
+++ b/lib/common/widgets/buttons/vertical_button.dart
@@ -5,17 +5,20 @@ import "../styling/button_styles.dart";
 
 class VerticalButton extends StatelessWidget {
   final String label;
-  final IconData icon;
-  final Color iconColor;
+  final IconData? icon;
+  final Color? iconColor;
+  final Widget? customWidget; // Nowy parametr dla custom widget
   final VoidCallback onPressed;
 
   const VerticalButton({
     super.key,
     required this.label,
-    required this.icon,
-    required this.iconColor,
+    this.icon,
+    this.iconColor,
+    this.customWidget,
     required this.onPressed,
-  });
+  }) : assert(icon != null || customWidget != null, 'Either icon or customWidget must be provided'),
+       assert(!(icon != null && customWidget != null), 'Cannot provide both icon and customWidget');
 
   @override
   Widget build(BuildContext context) {
@@ -37,7 +40,7 @@ class VerticalButton extends StatelessWidget {
             child: Text(label, style: context.textTheme.labelMedium, textAlign: TextAlign.center),
           ),
           const Spacer(),
-          Icon(icon, size: VerticalButtonConfig.iconSize, color: iconColor),
+          customWidget ?? Icon(icon!, size: VerticalButtonConfig.iconSize, color: iconColor!),
           const Spacer(),
         ],
       ),

--- a/lib/common/widgets/buttons/vertical_button.dart
+++ b/lib/common/widgets/buttons/vertical_button.dart
@@ -7,7 +7,7 @@ class VerticalButton extends StatelessWidget {
   final String label;
   final IconData? icon;
   final Color? iconColor;
-  final Widget? customWidget; // Nowy parametr dla custom widget
+  final Widget? customWidget;
   final VoidCallback onPressed;
 
   const VerticalButton({
@@ -17,8 +17,8 @@ class VerticalButton extends StatelessWidget {
     this.iconColor,
     this.customWidget,
     required this.onPressed,
-  }) : assert(icon != null || customWidget != null, 'Either icon or customWidget must be provided'),
-       assert(!(icon != null && customWidget != null), 'Cannot provide both icon and customWidget');
+  }) : assert(icon != null || customWidget != null, "Either icon or customWidget must be provided"),
+       assert(!(icon != null && customWidget != null), "Cannot provide both icon and customWidget");
 
   @override
   Widget build(BuildContext context) {
@@ -40,7 +40,7 @@ class VerticalButton extends StatelessWidget {
             child: Text(label, style: context.textTheme.labelMedium, textAlign: TextAlign.center),
           ),
           const Spacer(),
-          customWidget ?? Icon(icon!, size: VerticalButtonConfig.iconSize, color: iconColor!),
+          customWidget ?? Icon(icon, size: VerticalButtonConfig.iconSize, color: iconColor),
           const Spacer(),
         ],
       ),

--- a/lib/common/widgets/buttons/vertical_button.dart
+++ b/lib/common/widgets/buttons/vertical_button.dart
@@ -14,6 +14,7 @@ class VerticalButton extends StatelessWidget {
     super.key,
     required this.label,
     this.icon,
+
     this.iconColor,
     this.customWidget,
     required this.onPressed,

--- a/lib/common/widgets/progress/circular_progress.dart
+++ b/lib/common/widgets/progress/circular_progress.dart
@@ -2,11 +2,11 @@ import "dart:math" as math;
 import "package:flutter/material.dart" hide Route;
 
 class CircularProgressWithText extends StatelessWidget {
-  final double progress; // 0.0–1.0
+  final double progress;
   final double size;
   final double strokeWidth;
   final Color backgroundColor;
-  final Color progressColor;
+  final Gradient progressGradient;
   final TextStyle? textStyle;
 
   const CircularProgressWithText({
@@ -15,7 +15,7 @@ class CircularProgressWithText extends StatelessWidget {
     required this.size,
     required this.strokeWidth,
     required this.backgroundColor,
-    required this.progressColor,
+    required this.progressGradient,
     this.textStyle,
   });
 
@@ -33,8 +33,9 @@ class CircularProgressWithText extends StatelessWidget {
             painter: _CircularProgressPainter(
               progress: animatedValue,
               backgroundColor: backgroundColor,
-              progressColor: progressColor,
+              progressGradient: progressGradient,
               strokeWidth: strokeWidth,
+              size: size,
             ),
             child: Center(child: Text("${(animatedValue * 100).round()}%", style: textStyle)),
           ),
@@ -47,14 +48,16 @@ class CircularProgressWithText extends StatelessWidget {
 class _CircularProgressPainter extends CustomPainter {
   final double progress;
   final Color backgroundColor;
-  final Color progressColor;
+  final Gradient progressGradient;
   final double strokeWidth;
+  final double size;
 
   _CircularProgressPainter({
     required this.progress,
     required this.backgroundColor,
-    required this.progressColor,
+    required this.progressGradient,
     required this.strokeWidth,
+    required this.size,
   });
 
   @override
@@ -70,22 +73,25 @@ class _CircularProgressPainter extends CustomPainter {
           ..strokeWidth = strokeWidth
           ..strokeCap = StrokeCap.round;
 
+    final rect = Rect.fromCircle(center: center, radius: radius);
+    final shader = progressGradient.createShader(rect);
+
     final fg =
         Paint()
-          ..color = progressColor
+          ..shader = shader
           ..style = PaintingStyle.stroke
           ..strokeWidth = strokeWidth
           ..strokeCap = StrokeCap.round;
 
     canvas.drawCircle(center, radius, bg);
 
-    canvas.drawArc(Rect.fromCircle(center: center, radius: radius), startAngle, -2 * math.pi * progress, false, fg);
+    canvas.drawArc(rect, startAngle, -2 * math.pi * progress, false, fg);
   }
 
   @override
   bool shouldRepaint(covariant _CircularProgressPainter old) =>
       old.progress != progress ||
       old.backgroundColor != backgroundColor ||
-      old.progressColor != progressColor ||
+      old.progressGradient != progressGradient ||
       old.strokeWidth != strokeWidth;
 }

--- a/lib/common/widgets/progress/circular_progress.dart
+++ b/lib/common/widgets/progress/circular_progress.dart
@@ -1,0 +1,91 @@
+import "dart:math" as math;
+import "package:flutter/material.dart" hide Route;
+
+class CircularProgressWithText extends StatelessWidget {
+  final double progress; // 0.0–1.0
+  final double size;
+  final double strokeWidth;
+  final Color backgroundColor;
+  final Color progressColor;
+  final TextStyle? textStyle;
+
+  const CircularProgressWithText({
+    super.key,
+    required this.progress,
+    required this.size,
+    required this.strokeWidth,
+    required this.backgroundColor,
+    required this.progressColor,
+    this.textStyle,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return TweenAnimationBuilder<double>(
+      tween: Tween(begin: 0, end: progress.clamp(0, 1)),
+      duration: const Duration(milliseconds: 800),
+      curve: Curves.easeOutCubic,
+      builder: (context, animatedValue, _) {
+        return SizedBox(
+          width: size,
+          height: size,
+          child: CustomPaint(
+            painter: _CircularProgressPainter(
+              progress: animatedValue,
+              backgroundColor: backgroundColor,
+              progressColor: progressColor,
+              strokeWidth: strokeWidth,
+            ),
+            child: Center(child: Text("${(animatedValue * 100).round()}%", style: textStyle)),
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _CircularProgressPainter extends CustomPainter {
+  final double progress;
+  final Color backgroundColor;
+  final Color progressColor;
+  final double strokeWidth;
+
+  _CircularProgressPainter({
+    required this.progress,
+    required this.backgroundColor,
+    required this.progressColor,
+    required this.strokeWidth,
+  });
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final center = Offset(size.width / 2, size.height / 2);
+    final radius = (size.shortestSide / 2) - (strokeWidth / 2);
+    const startAngle = -math.pi / 2;
+
+    final bg =
+        Paint()
+          ..color = backgroundColor
+          ..style = PaintingStyle.stroke
+          ..strokeWidth = strokeWidth
+          ..strokeCap = StrokeCap.round;
+
+    final fg =
+        Paint()
+          ..color = progressColor
+          ..style = PaintingStyle.stroke
+          ..strokeWidth = strokeWidth
+          ..strokeCap = StrokeCap.round;
+
+    canvas.drawCircle(center, radius, bg);
+
+    canvas.drawArc(Rect.fromCircle(center: center, radius: radius), startAngle, -2 * math.pi * progress, false, fg);
+  }
+
+  @override
+  bool shouldRepaint(covariant _CircularProgressPainter old) =>
+      old.progress != progress ||
+      old.backgroundColor != backgroundColor ||
+      old.progressColor != progressColor ||
+      old.strokeWidth != strokeWidth;
+}

--- a/lib/features/home/views/home_view.dart
+++ b/lib/features/home/views/home_view.dart
@@ -1,5 +1,6 @@
 import "package:fast_immutable_collections/fast_immutable_collections.dart";
 import "package:flutter/material.dart" hide Route;
+import "package:flutter_riverpod/flutter_riverpod.dart";
 import "../../../../app/config/ui_config.dart";
 import "../../../../app/l10n/l10n.dart";
 import "../../../app/app.dart";
@@ -10,13 +11,13 @@ import "../../../common/widgets/styling/section_header.dart";
 import "../widgets/button_row.dart";
 import "../widgets/start_route_button.dart";
 
-class HomeView extends StatelessWidget {
+class HomeView extends ConsumerWidget {
   const HomeView({super.key, required this.routes});
 
   final IList<Route> routes;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     return Scaffold(
       appBar: const CommonAppBar(),
       body: ListView(

--- a/lib/features/home/widgets/button_row.dart
+++ b/lib/features/home/widgets/button_row.dart
@@ -1,15 +1,17 @@
 import "package:flutter/material.dart";
-
+import "package:flutter_riverpod/flutter_riverpod.dart";
 import "../../../../app/config/ui_config.dart";
 import "../../../../app/l10n/l10n.dart";
 import "../../../../app/theme/app_theme.dart";
 import "../../../app/app.dart";
+import "../../../common/providers/progress_provider.dart";
 import "../../../common/utils/url_launcher.dart";
 import "../../../common/widgets/buttons/vertical_button.dart";
+import "../../../common/widgets/progress/circular_progress.dart";
 
-class HomeButtonsRow extends StatelessWidget {
+class HomeButtonsRow extends ConsumerWidget {
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: AppPaddings.medium),
       child: SizedBox(
@@ -18,11 +20,42 @@ class HomeButtonsRow extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
             Expanded(
-              child: VerticalButton(
-                label: context.l10n.common_finished_routes,
-                icon: Icons.auto_graph,
-                iconColor: context.colorScheme.primary,
-                onPressed: context.router.goProfile,
+              child: Consumer(
+                builder: (context, ref, child) {
+                  final progressAsync = ref.watch(routeProgressProvider);
+                  return progressAsync.when(
+                    data:
+                        (progress) => VerticalButton(
+                          label: context.l10n.common_finished_routes,
+                          customWidget: CircularProgressWithText(
+                            progress: 0.7,
+                            size: 75,
+                            strokeWidth: 8,
+                            backgroundColor: context.colorScheme.primary.withValues(alpha: 0.2),
+                            progressColor: context.colorScheme.primary,
+                            textStyle: context.textTheme.labelLarge?.copyWith(
+                              color: context.colorScheme.primary,
+                              fontWeight: FontWeight.bold,
+                            ),
+                          ),
+                          onPressed: context.router.goProfile,
+                        ),
+                    loading:
+                        () => VerticalButton(
+                          label: context.l10n.common_finished_routes,
+                          icon: Icons.auto_graph,
+                          iconColor: context.colorScheme.primary,
+                          onPressed: context.router.goProfile,
+                        ),
+                    error:
+                        (error, stack) => VerticalButton(
+                          label: context.l10n.common_finished_routes,
+                          icon: Icons.wifi_off,
+                          iconColor: Colors.grey,
+                          onPressed: context.router.goProfile,
+                        ),
+                  );
+                },
               ),
             ),
             const SizedBox(width: HomeViewConfig.commonGap),

--- a/lib/features/home/widgets/button_row.dart
+++ b/lib/features/home/widgets/button_row.dart
@@ -28,11 +28,19 @@ class HomeButtonsRow extends ConsumerWidget {
                         (progress) => VerticalButton(
                           label: context.l10n.common_finished_routes,
                           customWidget: CircularProgressWithText(
-                            progress: 0.7,
+                            progress: progress,
                             size: 75,
                             strokeWidth: 8,
                             backgroundColor: context.colorScheme.primary.withValues(alpha: 0.2),
-                            progressColor: context.colorScheme.primary,
+                            progressGradient: LinearGradient(
+                              colors: [
+                                context.colorScheme.primary,
+                                context.colorScheme.secondary,
+                                context.colorScheme.error,
+                              ],
+                              begin: Alignment.topLeft,
+                              end: Alignment.bottomRight,
+                            ),
                             textStyle: context.textTheme.labelLarge?.copyWith(
                               color: context.colorScheme.primary,
                               fontWeight: FontWeight.bold,

--- a/lib/features/home/widgets/button_row.dart
+++ b/lib/features/home/widgets/button_row.dart
@@ -29,7 +29,7 @@ class HomeButtonsRow extends ConsumerWidget {
                           label: context.l10n.common_finished_routes,
                           customWidget: CircularProgressWithText(
                             progress: progress,
-                            size: 75,
+                            size: VerticalButtonConfig.iconSize - 8, //  - strokeWidth
                             strokeWidth: 8,
                             backgroundColor: context.colorScheme.primary.withValues(alpha: 0.2),
                             progressGradient: LinearGradient(

--- a/lib/features/home/widgets/button_row.dart
+++ b/lib/features/home/widgets/button_row.dart
@@ -20,53 +20,41 @@ class HomeButtonsRow extends ConsumerWidget {
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
             Expanded(
-              child: Consumer(
-                builder: (context, ref, child) {
-                  final progressAsync = ref.watch(routeProgressProvider);
-                  return progressAsync.when(
-                    data:
-                        (progress) => VerticalButton(
-                          label: context.l10n.common_finished_routes,
-                          customWidget: CircularProgressWithText(
-                            progress: progress,
-                            size: VerticalButtonConfig.iconSize - CircularProgressConfig.strokeWidth,
-                            strokeWidth: CircularProgressConfig.strokeWidth,
-                            backgroundColor: context.colorScheme.primary.withValues(
-                              alpha: CircularProgressConfig.backgroundAlpha,
-                            ),
-                            progressGradient: LinearGradient(
-                              colors: [
-                                context.colorScheme.primary,
-                                context.colorScheme.secondary,
-                                context.colorScheme.error,
-                              ],
-                              begin: Alignment.topLeft,
-                              end: Alignment.bottomRight,
-                            ),
-                            textStyle: context.textTheme.labelLarge?.copyWith(
-                              color: context.colorScheme.primary,
-                              fontWeight: FontWeight.bold,
-                            ),
-                          ),
-                          onPressed: context.router.goProfile,
-                        ),
-                    loading:
-                        () => VerticalButton(
-                          label: context.l10n.common_finished_routes,
-                          icon: Icons.auto_graph,
-                          iconColor: context.colorScheme.primary,
-                          onPressed: context.router.goProfile,
-                        ),
-                    error:
-                        (error, stack) => VerticalButton(
-                          label: context.l10n.common_finished_routes,
-                          icon: Icons.wifi_off,
-                          iconColor: Colors.grey,
-                          onPressed: context.router.goProfile,
-                        ),
-                  );
-                },
-              ),
+              child: () {
+                final progressAsync = ref.watch(routeProgressProvider);
+
+                return switch (progressAsync) {
+                  AsyncData(:final value) => VerticalButton(
+                    label: context.l10n.common_finished_routes,
+                    customWidget: CircularProgressWithText(
+                      progress: value,
+                      size: VerticalButtonConfig.iconSize - CircularProgressConfig.strokeWidth,
+                      strokeWidth: CircularProgressConfig.strokeWidth,
+                      backgroundColor: context.colorScheme.primary.withValues(
+                        alpha: CircularProgressConfig.backgroundAlpha,
+                      ),
+                      progressGradient: CircularProgressConfig.createProgressGradient(context.colorScheme),
+                      textStyle: CircularProgressConfig.createProgressTextStyle(
+                        context.colorScheme,
+                        context.textTheme.labelLarge,
+                      ),
+                    ),
+                    onPressed: context.router.goProfile,
+                  ),
+                  AsyncError() => VerticalButton(
+                    label: context.l10n.common_finished_routes,
+                    icon: Icons.wifi_off,
+                    iconColor: Colors.grey,
+                    onPressed: context.router.goProfile,
+                  ),
+                  _ => VerticalButton(
+                    label: context.l10n.common_finished_routes,
+                    icon: Icons.auto_graph,
+                    iconColor: context.colorScheme.primary,
+                    onPressed: context.router.goProfile,
+                  ),
+                };
+              }(),
             ),
             const SizedBox(width: HomeViewConfig.commonGap),
             Expanded(

--- a/lib/features/home/widgets/button_row.dart
+++ b/lib/features/home/widgets/button_row.dart
@@ -29,9 +29,11 @@ class HomeButtonsRow extends ConsumerWidget {
                           label: context.l10n.common_finished_routes,
                           customWidget: CircularProgressWithText(
                             progress: progress,
-                            size: VerticalButtonConfig.iconSize - 8, //  - strokeWidth
-                            strokeWidth: 8,
-                            backgroundColor: context.colorScheme.primary.withValues(alpha: 0.2),
+                            size: VerticalButtonConfig.iconSize - CircularProgressConfig.strokeWidth,
+                            strokeWidth: CircularProgressConfig.strokeWidth,
+                            backgroundColor: context.colorScheme.primary.withValues(
+                              alpha: CircularProgressConfig.backgroundAlpha,
+                            ),
                             progressGradient: LinearGradient(
                               colors: [
                                 context.colorScheme.primary,


### PR DESCRIPTION
- Added ProgressProvider and integrated it into HomeView.
- Updated VerticalButton to accept not only an icon but also a customWidget.
- Created a CircularProgressBar component.
- In the ButtonRow, the circular progress bar size is now calculated dynamically based on the icon size from the config (stroke) so that both circles are exactly the same size.

See images below for reference.

<img width="336" height="233" alt="Screenshot 2025-08-09 at 13 29 36" src="https://github.com/user-attachments/assets/81a24873-57ee-40bf-b298-6d4dce0bd428" />
<img width="343" height="242" alt="Screenshot 2025-08-09 at 13 29 15" src="https://github.com/user-attachments/assets/8191392c-46d7-4f71-9b56-99127c1a717b" />
<img width="163" height="214" alt="Screenshot 2025-08-09 at 13 00 37" src="https://github.com/user-attachments/assets/5f4191bb-4076-4b58-a93f-9b40867e5058" />
<img width="165" height="218" alt="Screenshot 2025-08-09 at 13 01 32" src="https://github.com/user-attachments/assets/9dc80094-674f-45b9-a9c0-23cdafb69488" />
