### PR TITLE
fix: creators image aspect ratio

### DIFF
--- a/lib/features/info/widgets/creator_tile/creator_tile.dart
+++ b/lib/features/info/widgets/creator_tile/creator_tile.dart
@@ -21,11 +21,20 @@ class CreatorTile extends StatelessWidget {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            CachedImage(CachedImageConfig.getDirectusUrl(creator.imageUrl)),
+            ClipRRect(
+              borderRadius: const BorderRadius.only(
+                topLeft: Radius.circular(InfoSectionConfig.radius),
+                topRight: Radius.circular(InfoSectionConfig.radius),
+              ),
+              child: AspectRatio(
+                aspectRatio: 1,
+                child: CachedImage(CachedImageConfig.getDirectusUrl(creator.imageUrl)),
+              ),
+            ),
+            const SizedBox(height: AppPaddings.tiny),
             Text("${creator.firstName} ${creator.lastName}", style: context.textTheme.bodyMedium),
             Text(creator.role, style: context.textTheme.bodySmall),
             if (creator.socialUrls != null) SocialsSection(socials: creator.socialUrls!),
-            const SizedBox(height: AppPaddings.tiny),
           ],
         ),
       ),


### PR DESCRIPTION
Previously, vertical images would take up all the space on a creator's card. Images in the creators section have been restrained to the 1:1 aspect ratio, so that the oversized ones are cropped.