### PR TITLE
fix: trigger sheet when selecting route

### DIFF
--- a/lib/common/providers/bottom_sheet_providers.dart
+++ b/lib/common/providers/bottom_sheet_providers.dart
@@ -4,7 +4,7 @@ enum SheetMode { half, expanded }
 
 enum SheetState { hidden, visible }
 
-final sheetModeProvider = StateProvider<SheetMode>((ref) => SheetMode.half);
+final sheetModeProvider = StateProvider<SheetMode>((ref) => SheetMode.expanded);
 
 final sheetStateProvider = StateProvider<SheetState>((ref) => SheetState.hidden);
 

--- a/lib/common/widgets/map_bottom_sheet.dart
+++ b/lib/common/widgets/map_bottom_sheet.dart
@@ -17,12 +17,14 @@ class MapBottomSheet extends ConsumerStatefulWidget {
 
 class _MapBottomSheetState extends ConsumerState<MapBottomSheet> {
   final DraggableScrollableController controller = DraggableScrollableController();
+  bool isAnimating = false;
 
   @override
   void initState() {
     super.initState();
     controller.addListener(() {
       final currentPosition = controller.size;
+      if (isAnimating) return;
       ref.read(sheetStateProvider.notifier).state =
           currentPosition < BottomSheetConfig.hiddenSizePercent + BottomSheetConfig.tolerance
               ? SheetState.hidden
@@ -45,18 +47,17 @@ class _MapBottomSheetState extends ConsumerState<MapBottomSheet> {
     ref.listen<bool>(sheetTriggerProvider, (previous, shouldTrigger) async {
       if (shouldTrigger) {
         ref.read(sheetTriggerProvider.notifier).state = false;
-        if (!controller.isAttached) {
-          ref.read(sheetTriggerProvider.notifier).state = true;
-        }
-        debugPrint("Starting sheet animation to position: $sheetPosition");
-        Future.delayed(
-          Duration.zero,
-          () => controller.animateTo(
-            ref.read(sheetStateProvider) == SheetState.hidden ? BottomSheetConfig.hiddenSizePercent : sheetPosition,
+        final targetPosition =
+            ref.read(sheetStateProvider) == SheetState.hidden ? BottomSheetConfig.hiddenSizePercent : sheetPosition;
+        isAnimating = true;
+        await Future.delayed(Duration.zero, () async {
+          await controller.animateTo(
+            targetPosition,
             duration: const Duration(milliseconds: 300),
             curve: Curves.easeInOut,
-          ),
-        );
+          );
+        });
+        isAnimating = false;
       }
     });
 

--- a/lib/common/widgets/map_bottom_sheet.dart
+++ b/lib/common/widgets/map_bottom_sheet.dart
@@ -45,10 +45,17 @@ class _MapBottomSheetState extends ConsumerState<MapBottomSheet> {
     ref.listen<bool>(sheetTriggerProvider, (previous, shouldTrigger) async {
       if (shouldTrigger) {
         ref.read(sheetTriggerProvider.notifier).state = false;
-        await controller.animateTo(
-          ref.read(sheetStateProvider) == SheetState.hidden ? BottomSheetConfig.hiddenSizePercent : sheetPosition,
-          duration: const Duration(milliseconds: 300),
-          curve: Curves.easeInOut,
+        if (!controller.isAttached) {
+          ref.read(sheetTriggerProvider.notifier).state = true;
+        }
+        debugPrint("Starting sheet animation to position: $sheetPosition");
+        Future.delayed(
+          Duration.zero,
+          () => controller.animateTo(
+            ref.read(sheetStateProvider) == SheetState.hidden ? BottomSheetConfig.hiddenSizePercent : sheetPosition,
+            duration: const Duration(milliseconds: 300),
+            curve: Curves.easeInOut,
+          ),
         );
       }
     });

--- a/lib/features/home/widgets/start_route_button.dart
+++ b/lib/features/home/widgets/start_route_button.dart
@@ -1,13 +1,14 @@
 import "package:flutter/material.dart";
+import "package:flutter_riverpod/flutter_riverpod.dart";
 import "../../../../app/config/ui_config.dart";
 import "../../../../app/l10n/l10n.dart";
 import "../../../../app/theme/app_theme.dart";
 import "../../../app/app.dart";
 import "../../../common/widgets/styling/button_styles.dart";
 
-class StartRouteButton extends StatelessWidget {
+class StartRouteButton extends ConsumerWidget {
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: AppPaddings.medium),
       child: ElevatedButton(

--- a/lib/features/route_map/route_map_page.dart
+++ b/lib/features/route_map/route_map_page.dart
@@ -33,6 +33,7 @@ class _RouteMapPageState extends ConsumerState<RouteMapPage> {
   void _initializeState(WidgetRef ref, {Route? route}) {
     ref.read(routeProvider.notifier).state = route;
     ref.read(sheetStateProvider.notifier).state = route == null ? SheetState.visible : SheetState.hidden;
+    ref.read(sheetModeProvider.notifier).state = route == null ? SheetMode.expanded : SheetMode.half;
     ref.read(passedLocationsProvider.notifier).state = 0;
     ref.read(visitedCountProvider.notifier).resetVisited();
     ref.read(expandedRoutesProvider.notifier).state = LinkedHashSet();

--- a/lib/features/route_map/route_map_page.dart
+++ b/lib/features/route_map/route_map_page.dart
@@ -32,10 +32,14 @@ class RouteMapPage extends ConsumerStatefulWidget {
 class _RouteMapPageState extends ConsumerState<RouteMapPage> {
   void _initializeState(WidgetRef ref, {Route? route}) {
     ref.read(routeProvider.notifier).state = route;
-    ref.read(sheetStateProvider.notifier).state = SheetState.hidden;
+    ref.read(sheetStateProvider.notifier).state = route == null ? SheetState.visible : SheetState.hidden;
     ref.read(passedLocationsProvider.notifier).state = 0;
     ref.read(visitedCountProvider.notifier).resetVisited();
     ref.read(expandedRoutesProvider.notifier).state = LinkedHashSet();
+    if (route == null && ref.read(sheetStateProvider) == SheetState.visible) {
+      debugPrint("It was set to visible, awaiting");
+      ref.read(sheetTriggerProvider.notifier).state = true;
+    }
   }
 
   void _initializeBackgroundTracking(WidgetRef ref, BuildContext context, Route? route) {

--- a/lib/features/route_map/route_map_page.dart
+++ b/lib/features/route_map/route_map_page.dart
@@ -37,7 +37,6 @@ class _RouteMapPageState extends ConsumerState<RouteMapPage> {
     ref.read(visitedCountProvider.notifier).resetVisited();
     ref.read(expandedRoutesProvider.notifier).state = LinkedHashSet();
     if (route == null && ref.read(sheetStateProvider) == SheetState.visible) {
-      debugPrint("It was set to visible, awaiting");
       ref.read(sheetTriggerProvider.notifier).state = true;
     }
   }
@@ -108,7 +107,7 @@ class _RouteMapPageState extends ConsumerState<RouteMapPage> {
     });
 
     return switch (routeAsync) {
-      AsyncData() => const RouteMapView(),
+      AsyncData() => RouteMapView(route: routeAsync.value),
       AsyncError(:final error) => ErrorPage(onBackToHome: context.router.goHome, message: error.toString()),
       _ => const Center(child: CircularProgressIndicator()),
     };

--- a/lib/features/route_map/views/route_map_view.dart
+++ b/lib/features/route_map/views/route_map_view.dart
@@ -1,14 +1,14 @@
 import "dart:async";
-import "package:flutter/material.dart";
+import "package:flutter/material.dart" hide Route;
 import "package:flutter_map_animations/flutter_map_animations.dart";
 import "package:flutter_riverpod/flutter_riverpod.dart";
 import "../../../app/l10n/l10n.dart";
 import "../../../app/theme/app_theme.dart";
+import "../../../common/models/route.dart";
 import "../../../common/providers/bottom_sheet_providers.dart";
 import "../../../common/utils/location_service.dart";
 import "../../../common/utils/modal_before_exiting.dart";
 import "../modals/end_route_modal.dart";
-import "../providers/route_provider.dart";
 import "../repository/route_map_repository.dart";
 import "../widgets/bottom_sheet/route_bottom_sheet.dart";
 import "../widgets/bottom_sheet/select_route_bottom_sheet.dart";
@@ -16,7 +16,8 @@ import "../widgets/map/route_map_widget.dart";
 import "../widgets/progress_bar/route_progress_bar.dart";
 
 class RouteMapView extends ConsumerStatefulWidget {
-  const RouteMapView({super.key});
+  const RouteMapView({super.key, this.route});
+  final Route? route;
 
   @override
   RouteMapViewState createState() => RouteMapViewState();
@@ -55,7 +56,7 @@ class RouteMapViewState extends ConsumerState<RouteMapView> with TickerProviderS
 
   @override
   Widget build(BuildContext context) {
-    final route = ref.watch(routeProvider);
+    final route = widget.route;
     final allRoutesAsync = ref.watch(fetchAllRoutesProvider);
 
     ref.listen<SheetMode>(sheetModeProvider, (previous, next) {

--- a/lib/features/route_map/widgets/bottom_sheet/route_bottom_sheet.dart
+++ b/lib/features/route_map/widgets/bottom_sheet/route_bottom_sheet.dart
@@ -47,6 +47,7 @@ class RouteBottomSheetState extends ConsumerState<RouteBottomSheet> {
         text: context.l10n.end_route,
         backgroundColor: context.colorScheme.error,
         onPressed: () async {
+          ref.read(sheetStateProvider.notifier).state = SheetState.hidden;
           ref.read(sheetTriggerProvider.notifier).state = true;
           final bool shouldPop =
               await showDialog<bool>(context: context, builder: (context) => EndRouteModal(route: widget.route)) ??

--- a/lib/features/route_map/widgets/bottom_sheet/select_route_bottom_sheet.dart
+++ b/lib/features/route_map/widgets/bottom_sheet/select_route_bottom_sheet.dart
@@ -34,6 +34,8 @@ class SelectRouteBottomSheetState extends ConsumerState<SelectRouteBottomSheet> 
       button: MainActionButton(
         text: context.l10n.browse_routes,
         onPressed: () {
+          debugPrint(ref.read(sheetStateProvider).toString());
+          debugPrint(ref.read(sheetTriggerProvider).toString());
           if (ref.read(sheetStateProvider) == SheetState.hidden) {
             ref.read(sheetStateProvider.notifier).state = SheetState.visible;
           } else {

--- a/lib/features/route_map/widgets/bottom_sheet/select_route_bottom_sheet.dart
+++ b/lib/features/route_map/widgets/bottom_sheet/select_route_bottom_sheet.dart
@@ -34,8 +34,6 @@ class SelectRouteBottomSheetState extends ConsumerState<SelectRouteBottomSheet> 
       button: MainActionButton(
         text: context.l10n.browse_routes,
         onPressed: () {
-          debugPrint(ref.read(sheetStateProvider).toString());
-          debugPrint(ref.read(sheetTriggerProvider).toString());
           if (ref.read(sheetStateProvider) == SheetState.hidden) {
             ref.read(sheetStateProvider.notifier).state = SheetState.visible;
           } else {


### PR DESCRIPTION
Now, when clicking on the Rozpocznij Spacer button, the sheet expands after opening the view. While making these changes I encountered a bug: RouteMapView used a route provider to determine which bottom sheet to load. When route map page was first opened with a route, and then without a route, the route was determined by passing the route id to the RouteMapPage, and based on the id, the routeProvider was updated. HOWEVER, the provider would not finish updating its state before RouteMapView already started building BottomSheet based on the outdated provider state. The resulting effect was: 

1 - user opens a map with a selected route. 
2 - user exits. 
3 - user open a map without a route.
4 - a bottom sheet for the previously selected route starts building.
5 - the bottom sheet starts performing the opening animation - based on the sheet state and sheet trigger provider.
6 - routeProvider finally finishes updating.
7 - RouteMapView gets the info that it should build the bottom sheet for selecting routes.
8 - bottom sheet for the previous route gets destroyed - the animation didn't yet finish playing - the app crashes.
9 - the correct bottom sheet gets build.

This error only started occurring when I would trigger the sheet animation right away when the view is building, so that it's ready for the user, but it did uncover the underlying problem which was the first build of the routeMapView with the wrong route information. I fixed this by passing the route to the RouteMapView directly instead of getting it inside a view from a provider.