### PR TITLE
refactor: segmented button in route info sheet

### DIFF
--- a/lib/app/config/ui_config.dart
+++ b/lib/app/config/ui_config.dart
@@ -95,6 +95,10 @@ abstract class ButtonsConfig {
   static const secondaryButtonRadius = 20.0;
   static const secondaryButtonShadowRadius = 25.0;
   static const secondaryButtonPadding = 6.0;
+
+  static const segmentedButtonBorderWidth = 2.0;
+  static const segmentedButtonFontSize = 14.0;
+  static const segmentedButtonFontWeight = FontWeight.w500;
 }
 
 abstract class InfoModalConfig {

--- a/lib/common/widgets/buttons/route_segmented_button.dart
+++ b/lib/common/widgets/buttons/route_segmented_button.dart
@@ -1,0 +1,51 @@
+import "package:flutter/material.dart";
+
+import "../../../app/config/ui_config.dart";
+import "../../../app/l10n/l10n.dart";
+import "../../../app/theme/color_consts.dart";
+import "../../../features/route_map/providers/route_provider.dart";
+
+class RouteSegmentedButton extends StatelessWidget {
+  const RouteSegmentedButton({super.key, required this.chosenOption, required this.onSelectionChanged});
+
+  final RouteDetailsOption chosenOption;
+  final void Function(Set<RouteDetailsOption>) onSelectionChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return SegmentedButton<RouteDetailsOption>(
+      showSelectedIcon: false,
+      style: SegmentedButton.styleFrom(
+        backgroundColor: ColorConsts.whiteGray,
+        foregroundColor: ColorConsts.plumosa,
+        selectedForegroundColor: ColorConsts.whiteGray,
+        selectedBackgroundColor: ColorConsts.plumosa,
+        side: const BorderSide(color: ColorConsts.plumosa, width: ButtonsConfig.segmentedButtonBorderWidth),
+      ),
+      segments: <ButtonSegment<RouteDetailsOption>>[
+        ButtonSegment<RouteDetailsOption>(
+          value: RouteDetailsOption.info,
+          label: Text(
+            context.l10n.route_description,
+            style: const TextStyle(
+              fontSize: ButtonsConfig.segmentedButtonFontSize,
+              fontWeight: ButtonsConfig.segmentedButtonFontWeight,
+            ),
+          ),
+        ),
+        ButtonSegment<RouteDetailsOption>(
+          value: RouteDetailsOption.playlist,
+          label: Text(
+            context.l10n.playlist,
+            style: const TextStyle(
+              fontSize: ButtonsConfig.segmentedButtonFontSize,
+              fontWeight: ButtonsConfig.segmentedButtonFontWeight,
+            ),
+          ),
+        ),
+      ],
+      selected: <RouteDetailsOption>{chosenOption},
+      onSelectionChanged: onSelectionChanged,
+    );
+  }
+}

--- a/lib/features/route_map/widgets/bottom_sheet/route_bottom_sheet.dart
+++ b/lib/features/route_map/widgets/bottom_sheet/route_bottom_sheet.dart
@@ -6,11 +6,10 @@ import "package:go_router/go_router.dart";
 import "../../../../app/config/ui_config.dart";
 import "../../../../app/l10n/l10n.dart";
 import "../../../../app/theme/app_theme.dart";
-import "../../../../app/theme/color_consts.dart";
 import "../../../../common/models/route.dart";
 import "../../../../common/providers/bottom_sheet_providers.dart";
 import "../../../../common/widgets/buttons/main_action_button.dart";
-import "../../../../common/widgets/buttons/secondary_action_button.dart";
+import "../../../../common/widgets/buttons/route_segmented_button.dart";
 import "../../../../common/widgets/map_bottom_sheet.dart";
 import "../../modals/end_route_modal.dart";
 import "../../providers/route_provider.dart";
@@ -57,38 +56,19 @@ class RouteBottomSheetState extends ConsumerState<RouteBottomSheet> {
           }
         },
       ),
-      controls: Row(
-        spacing: BottomSheetHeaderConfig.controlsSpacing,
-        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-        children: [
-          Expanded(
-            child: SecondaryActionButton(
-              onPressed: () {
-                ref.read(sheetModeProvider.notifier).state = SheetMode.half;
-                setState(() {
-                  _chosenOption = RouteDetailsOption.info;
-                });
-              },
-              text: context.l10n.route_description,
-              backgroundColor: _chosenOption == RouteDetailsOption.info ? ColorConsts.plumosa : ColorConsts.whiteGray,
-              textColor: _chosenOption == RouteDetailsOption.info ? ColorConsts.whiteGray : ColorConsts.plumosa,
-            ),
-          ),
-          Expanded(
-            child: SecondaryActionButton(
-              onPressed: () {
-                ref.read(sheetModeProvider.notifier).state = SheetMode.expanded;
-                setState(() {
-                  _chosenOption = RouteDetailsOption.playlist;
-                });
-              },
-              text: context.l10n.playlist,
-              backgroundColor:
-                  _chosenOption == RouteDetailsOption.playlist ? ColorConsts.plumosa : ColorConsts.whiteGray,
-              textColor: _chosenOption == RouteDetailsOption.playlist ? ColorConsts.whiteGray : ColorConsts.plumosa,
-            ),
-          ),
-        ],
+      controls: Container(
+        padding: const EdgeInsets.symmetric(horizontal: AppPaddings.tiny),
+        width: double.infinity,
+        child: RouteSegmentedButton(
+          chosenOption: _chosenOption,
+          onSelectionChanged: (newSelection) {
+            ref.read(sheetModeProvider.notifier).state =
+                newSelection.first == RouteDetailsOption.info ? SheetMode.half : SheetMode.expanded;
+            setState(() {
+              _chosenOption = newSelection.first;
+            });
+          },
+        ),
       ),
       child:
           (_chosenOption == RouteDetailsOption.playlist && widget.route.playlist != null)

--- a/lib/features/route_map/widgets/bottom_sheet/tiles/route_tile.dart
+++ b/lib/features/route_map/widgets/bottom_sheet/tiles/route_tile.dart
@@ -5,8 +5,8 @@ import "../../../../../app/assets/assets.gen.dart";
 import "../../../../../app/config/ui_config.dart";
 import "../../../../../app/l10n/l10n.dart";
 import "../../../../../app/theme/app_theme.dart";
-import "../../../../../app/theme/color_consts.dart";
 import "../../../../../common/models/route.dart";
+import "../../../../../common/widgets/buttons/route_segmented_button.dart";
 import "../../../../../common/widgets/buttons/secondary_action_button.dart";
 import "../../../modals/start_route_modal.dart";
 import "../../../providers/route_provider.dart";
@@ -89,37 +89,17 @@ class RouteTileState extends ConsumerState<RouteTile> {
         ),
         Padding(
           padding: const EdgeInsets.all(AppPaddings.tinySmall),
-          child: Row(
-            spacing: BottomSheetHeaderConfig.controlsSpacing,
-            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-            children: [
-              Expanded(
-                child: SecondaryActionButton(
-                  onPressed: () {
-                    updateExpandedRoutes(route);
-                    setState(() => _chosenOption = RouteDetailsOption.info);
-                  },
-                  text: context.l10n.route_description,
-                  backgroundColor:
-                      _chosenOption != RouteDetailsOption.info ? ColorConsts.whiteGray : ColorConsts.plumosa,
-                  textColor: _chosenOption != RouteDetailsOption.info ? ColorConsts.plumosa : ColorConsts.whiteGray,
-                ),
-              ),
-              if (widget.route.playlist != null)
-                Expanded(
-                  child: SecondaryActionButton(
-                    onPressed: () {
-                      updateExpandedRoutes(route);
-                      setState(() => _chosenOption = RouteDetailsOption.playlist);
-                    },
-                    text: context.l10n.playlist,
-                    backgroundColor:
-                        _chosenOption != RouteDetailsOption.playlist ? ColorConsts.whiteGray : ColorConsts.plumosa,
-                    textColor:
-                        _chosenOption != RouteDetailsOption.playlist ? ColorConsts.plumosa : ColorConsts.whiteGray,
-                  ),
-                ),
-            ],
+          child: SizedBox(
+            width: double.infinity,
+            child: RouteSegmentedButton(
+              chosenOption: _chosenOption,
+              onSelectionChanged: (newSelection) {
+                updateExpandedRoutes(route);
+                setState(() {
+                  _chosenOption = newSelection.first;
+                });
+              },
+            ),
           ),
         ),
         const SizedBox(height: AppPaddings.small),


### PR DESCRIPTION
previously, there were two separate buttons in the bottom sheet for the info and playlist sections which could be confusing; remade into a segmented button. 
<img width="406" height="847" alt="image" src="https://github.com/user-attachments/assets/eb4e7794-7012-4207-be5c-ce6d6b934714" />
<img width="412" height="838" alt="image" src="https://github.com/user-attachments/assets/685557ab-e5c7-4786-9b79-7e443c006e48" />
