### PR TITLE
feat: custom toast for error

### DIFF
--- a/lib/app/l10n/arb/app_pl.arb
+++ b/lib/app/l10n/arb/app_pl.arb
@@ -83,6 +83,6 @@
   "info_feedback_button":"Wyślij",
 
   "apple_music_playlist_not_available": "Przepraszamy, playlista nie jest dostępna w Apple Music.",
-  "youtube_playlist_not_available": "Przepraszamy, playlista nie jest dostępna w YouTube."
+  "youtube_playlist_not_available": "Przepraszamy, playlista nie jest dostępna w YouTube Music."
 
 }

--- a/lib/app/l10n/arb/app_pl.arb
+++ b/lib/app/l10n/arb/app_pl.arb
@@ -80,6 +80,9 @@
   "app_feedback" : "Zgłoś błąd",
   "info_feedback_title": "Wyślij feedback",
   "info_feedback_subtitle": "Podziel się opinią o aplikacji",
-  "info_feedback_button":"Wyślij"
+  "info_feedback_button":"Wyślij",
+
+  "apple_music_playlist_not_available": "Przepraszamy, playlista nie jest dostępna w Apple Music.",
+  "youtube_playlist_not_available": "Przepraszamy, playlista nie jest dostępna w YouTube."
 
 }

--- a/lib/app/l10n/arb/app_pl.arb
+++ b/lib/app/l10n/arb/app_pl.arb
@@ -53,7 +53,7 @@
   "errors_generic":  "Coś poszło nie tak",
   "errors_launch": "Wystąpił błąd podczas otwierania adresu",
   "errors_stats": "Nie udało się załadować statystyk",
-  "browse_routes": "Przegądaj trasy",
+  "browse_routes": "Przeglądaj trasy",
   "choose_route": "Wybierz trasę",
   "start_route": "Rozpocznij trasę!",
   "start_route_modal_title": "Czy na pewno chcesz rozpocząć tę trasę?",

--- a/lib/common/utils/url_launcher.dart
+++ b/lib/common/utils/url_launcher.dart
@@ -1,8 +1,11 @@
 import "package:url_launcher/url_launcher.dart";
 
-Future<void> customLaunchUrl(String url) async {
+Future<bool> customLaunchUrl(String url) async {
+  if (url.isEmpty) return false;
   final uri = Uri.parse(url);
   if (await canLaunchUrl(uri)) {
     await launchUrl(uri, mode: LaunchMode.externalApplication);
+    return true;
   }
+  return false;
 }

--- a/lib/features/error/widgets/error_snack_bar.dart
+++ b/lib/features/error/widgets/error_snack_bar.dart
@@ -1,0 +1,17 @@
+import "package:flutter/material.dart";
+
+import "../../../app/config/ui_config.dart";
+import "../../../app/theme/app_theme.dart";
+import "../../../app/theme/color_consts.dart";
+
+extension ErrorSnackBar on BuildContext {
+  void showErrorSnackBar(String message) {
+    ScaffoldMessenger.of(this).showSnackBar(
+      SnackBar(
+        content: Text(message, style: textTheme.labelMedium),
+        padding: const EdgeInsets.all(AppPaddings.medium),
+        backgroundColor: ColorConsts.lightOrange,
+      ),
+    );
+  }
+}

--- a/lib/features/error/widgets/error_snack_bar.dart
+++ b/lib/features/error/widgets/error_snack_bar.dart
@@ -2,7 +2,6 @@ import "package:flutter/material.dart";
 
 import "../../../app/config/ui_config.dart";
 import "../../../app/theme/app_theme.dart";
-import "../../../app/theme/color_consts.dart";
 
 extension ErrorSnackBar on BuildContext {
   void showErrorSnackBar(String message) {
@@ -10,7 +9,7 @@ extension ErrorSnackBar on BuildContext {
       SnackBar(
         content: Text(message, style: textTheme.labelMedium),
         padding: const EdgeInsets.all(AppPaddings.medium),
-        backgroundColor: ColorConsts.lightOrange,
+        backgroundColor: colorScheme.error,
       ),
     );
   }

--- a/lib/features/route_map/route_map_page.dart
+++ b/lib/features/route_map/route_map_page.dart
@@ -9,6 +9,7 @@ import "../../common/models/route.dart";
 import "../../common/providers/bottom_sheet_providers.dart";
 import "../../common/providers/completed_routes_provider.dart";
 import "../error/error_page.dart";
+import "../error/widgets/error_snack_bar.dart";
 import "controllers/route_controller.dart" hide Distance;
 import "modals/route_completed_modal.dart";
 import "providers/locations_provider.dart";
@@ -73,7 +74,7 @@ class _RouteMapPageState extends ConsumerState<RouteMapPage> {
           await FlutterForegroundTask.stopService();
           await ref.read(completedRoutesProvider.notifier).addCompletedRoute(CompletedRoute.fromRoute(route));
         case TaskEvent.error:
-          ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text("Error: $data")));
+          context.showErrorSnackBar("Error: $data");
       }
     }
   }

--- a/lib/features/route_map/widgets/bottom_sheet/sections/playlist_info_section.dart
+++ b/lib/features/route_map/widgets/bottom_sheet/sections/playlist_info_section.dart
@@ -1,8 +1,10 @@
 import "package:flutter/material.dart";
 import "../../../../../app/config/ui_config.dart";
+import "../../../../../app/l10n/l10n.dart";
 import "../../../../../common/models/playlist.dart";
 import "../../../../../common/utils/url_launcher.dart";
 import "../../../../../common/widgets/buttons/secondary_action_button.dart";
+import "../../../../error/widgets/error_snack_bar.dart";
 import "song_tile.dart";
 
 class PlaylistInfoSection extends StatefulWidget {
@@ -38,13 +40,23 @@ class _PlaylistInfoSectionState extends State<PlaylistInfoSection> {
               Expanded(
                 child: SecondaryActionButton(
                   iconData: Icons.play_circle_fill,
-                  onPressed: () async => customLaunchUrl(playlist.youtubeUrl ?? ""),
+                  onPressed: () async {
+                    final launched = await customLaunchUrl(playlist.youtubeUrl ?? "");
+                    if (!launched && context.mounted) {
+                      context.showErrorSnackBar(context.l10n.youtube_playlist_not_available);
+                    }
+                  },
                 ),
               ),
               Expanded(
                 child: SecondaryActionButton(
                   iconData: Icons.apple,
-                  onPressed: () async => customLaunchUrl(playlist.appleUrl ?? ""),
+                  onPressed: () async {
+                    final launched = await customLaunchUrl(playlist.appleUrl ?? "");
+                    if (!launched && context.mounted) {
+                      context.showErrorSnackBar(context.l10n.apple_music_playlist_not_available);
+                    }
+                  },
                 ),
               ),
             ],


### PR DESCRIPTION
Add a function displaying a custom toast for informing about errors, use it for notifying when the playlist is not available on the music streaming service - previously it would fail silently or crash the app depending on the device. Also use the created function in the map widget.
<img width="399" height="829" alt="image" src="https://github.com/user-attachments/assets/1bbdd800-515d-4f64-82fa-5ce2a2954d12" />
