### PR TITLE
feat: show modal on achievement press

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -80,20 +80,20 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/url_launcher_ios/ios"
 
 SPEC CHECKSUMS:
-  device_info_plus: bf2e3232933866d73fe290f2942f2156cdd10342
+  device_info_plus: 21fcca2080fbcd348be798aa36c3e5ed849eefbe
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
-  flutter_foreground_task: 21ef182ab0a29a3005cc72cd70e5f45cb7f7f817
-  flutter_native_splash: df59bb2e1421aa0282cb2e95618af4dcb0c56c29
-  flutter_rotation_sensor: f37d8d24050572029bdd2d55a93e0f334e2eeac6
-  geolocator_apple: 66b711889fd333205763b83c9dcf0a57a28c7afd
-  native_device_orientation: 348b10c346a60ebbc62fb235a4fdb5d1b61a8f55
-  package_info_plus: c0502532a26c7662a62a356cebe2692ec5fe4ec4
-  path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
+  flutter_foreground_task: a159d2c2173b33699ddb3e6c2a067045d7cebb89
+  flutter_native_splash: c32d145d68aeda5502d5f543ee38c192065986cf
+  flutter_rotation_sensor: bf55ead3f64f27207dacc5972fe8ebe932f3de0b
+  geolocator_apple: ab36aa0e8b7d7a2d7639b3b4e48308394e8cef5e
+  native_device_orientation: e3580675687d5034770da198f6839ebf2122ef94
+  package_info_plus: af8e2ca6888548050f16fa2f1938db7b5a5df499
+  path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
   Sentry: 2cbbe3592f30050c60e916c63c7f5a2fa584005e
-  sentry_flutter: feb376a4d8fd37387898b94e00da2060eeab2a41
-  shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78
-  sqflite_darwin: 5a7236e3b501866c1c9befc6771dfd73ffb8702d
-  url_launcher_ios: 5334b05cef931de560670eeae103fd3e431ac3fe
+  sentry_flutter: 9b1e3e6934cb7040ffb71383c95a35f73523180c
+  shared_preferences_foundation: 9e1978ff2562383bd5676f64ec4e9aa8fa06a6f7
+  sqflite_darwin: 20b2a3a3b70e43edae938624ce550a3cbf66a3d0
+  url_launcher_ios: 694010445543906933d732453a59da0a173ae33d
 
 PODFILE CHECKSUM: 4305caec6b40dde0ae97be1573c53de1882a07e5
 

--- a/lib/app/config/ui_config.dart
+++ b/lib/app/config/ui_config.dart
@@ -211,6 +211,7 @@ abstract final class SectionAccentConfig {
 abstract final class ProfileViewConfig {
   static const double sideMargin = 10;
   static const double commonGap = 30;
+  static const double achievementsIconSize = 115;
 }
 
 abstract final class ProfileProgressBarConfig {

--- a/lib/common/data_source/mocks/mock_stats.dart
+++ b/lib/common/data_source/mocks/mock_stats.dart
@@ -1,17 +1,44 @@
 import "package:fast_immutable_collections/fast_immutable_collections.dart";
 import "package:flutter/material.dart";
-import "../../models/stats.dart";
+import "../../models/achievement.dart";
+import "../../models/stat.dart";
 
 final mockStats =
     [
-      Stats(id: 1, value: "10.5 km", iconData: Icons.directions_walk, iconColor: Colors.green.toARGB32()),
-      Stats(id: 2, value: "500 kcal", iconData: Icons.local_fire_department, iconColor: Colors.red.toARGB32()),
-      Stats(id: 3, value: "2 L", iconData: Icons.water_drop, iconColor: Colors.blue.toARGB32()),
-      Stats(id: 4, value: "3 h", iconData: Icons.schedule, iconColor: Colors.orange.toARGB32()),
+      Stat(id: 1, value: "10.5 km", iconData: Icons.directions_walk, iconColor: Colors.green.toARGB32()),
+      Stat(id: 2, value: "500 kcal", iconData: Icons.local_fire_department, iconColor: Colors.red.toARGB32()),
+      Stat(id: 3, value: "2 L", iconData: Icons.water_drop, iconColor: Colors.blue.toARGB32()),
+      Stat(id: 4, value: "3 h", iconData: Icons.schedule, iconColor: Colors.orange.toARGB32()),
     ].lock;
 
 final mockAchievements =
     [
-      Stats(id: 5, value: "Turysta", iconData: Icons.local_see, iconColor: Colors.black.toARGB32()),
-      Stats(id: 6, value: "Sigma", iconData: Icons.man_3, iconColor: Colors.black.toARGB32()),
+      Achievement(
+        id: 1,
+        value: "Pierwszy krok",
+        description: "Przejdź swoją pierwszą trasę w aplikacji.",
+        iconData: Icons.directions_walk,
+        iconColor: Colors.green.toARGB32(),
+      ),
+      Achievement(
+        id: 2,
+        value: "Turysta",
+        description: "Ukończ trzy różne trasy o sumarycznej długości większej niż sześć kilometrów.",
+        iconData: Icons.nordic_walking,
+        iconColor: Colors.black.toARGB32(),
+      ),
+      Achievement(
+        id: 2,
+        value: "Lubię wracać tam...",
+        description: "Ukończ tą samą trasę dwa razy.",
+        iconData: Icons.timelapse,
+        iconColor: Colors.brown.toARGB32(),
+      ),
+      Achievement(
+        id: 3,
+        value: "Zasłuchany",
+        description: "Przejdź wszystkie trasy dostępne w aplikacji conajmniej raz.",
+        iconData: Icons.music_note,
+        iconColor: Colors.blue.toARGB32(),
+      ),
     ].lock;

--- a/lib/common/models/achievement.dart
+++ b/lib/common/models/achievement.dart
@@ -1,0 +1,13 @@
+import "stat.dart";
+
+class Achievement extends Stat {
+  final String description;
+
+  Achievement({
+    required super.id,
+    required super.value,
+    required this.description,
+    required super.iconData,
+    required super.iconColor,
+  });
+}

--- a/lib/common/models/stat.dart
+++ b/lib/common/models/stat.dart
@@ -1,10 +1,10 @@
 import "package:flutter/widgets.dart";
 
-class Stats {
+class Stat {
   final int id;
   final String value;
   final IconData iconData;
   final int iconColor;
 
-  Stats({required this.id, required this.value, required this.iconData, required this.iconColor});
+  Stat({required this.id, required this.value, required this.iconData, required this.iconColor});
 }

--- a/lib/common/parsers/completed_routes_stats_converter.dart
+++ b/lib/common/parsers/completed_routes_stats_converter.dart
@@ -1,29 +1,24 @@
 import "package:fast_immutable_collections/fast_immutable_collections.dart";
 import "package:flutter/material.dart";
-import "../../common/models/stats.dart";
 import "../models/completed_route.dart";
 import "../models/route.dart";
+import "../models/stat.dart";
 
-IList<Stats> convertCompletedRoutesToStats(List<CompletedRoute> routes) {
+IList<Stat> convertCompletedRoutesToStats(List<CompletedRoute> routes) {
   final double totalDistance = routes.fold(0, (sum, r) => sum + r.distance);
   final int totalCalories = routes.fold(0, (sum, r) => sum + r.calories);
   final int totalWaterMl = routes.fold(0, (sum, r) => sum + r.water);
   final int totalTimeMinutes = routes.fold(0, (sum, r) => sum + r.time);
 
   return [
-    Stats(
+    Stat(
       id: 1,
       value: totalDistance.inKilometers(),
       iconData: Icons.directions_walk,
       iconColor: Colors.green.toARGB32(),
     ),
-    Stats(
-      id: 2,
-      value: totalCalories.inKcal(),
-      iconData: Icons.local_fire_department,
-      iconColor: Colors.red.toARGB32(),
-    ),
-    Stats(id: 3, value: totalWaterMl.inLiters(), iconData: Icons.water_drop, iconColor: Colors.yellow.toARGB32()),
-    Stats(id: 4, value: totalTimeMinutes.inHours(), iconData: Icons.schedule, iconColor: Colors.orange.toARGB32()),
+    Stat(id: 2, value: totalCalories.inKcal(), iconData: Icons.local_fire_department, iconColor: Colors.red.toARGB32()),
+    Stat(id: 3, value: totalWaterMl.inLiters(), iconData: Icons.water_drop, iconColor: Colors.yellow.toARGB32()),
+    Stat(id: 4, value: totalTimeMinutes.inHours(), iconData: Icons.schedule, iconColor: Colors.orange.toARGB32()),
   ].lock;
 }

--- a/lib/features/profile/views/profile_view.dart
+++ b/lib/features/profile/views/profile_view.dart
@@ -6,12 +6,15 @@ import "../../../../app/config/ui_config.dart";
 import "../../../../app/l10n/l10n.dart";
 import "../../../app/app.dart";
 import "../../../common/data_source/mocks/mock_stats.dart";
+import "../../../common/models/achievement.dart";
 import "../../../common/models/completed_route.dart";
 import "../../../common/models/route.dart";
+import "../../../common/models/stat.dart";
 import "../../../common/parsers/completed_routes_stats_converter.dart";
 import "../../../common/widgets/app_bar.dart";
 import "../../../common/widgets/horizontal_routes_list/horizontal_routes_list.dart";
 import "../../../common/widgets/styling/section_header.dart";
+import "../widgets/achivement_description_modal.dart";
 import "../widgets/horizontal_stat_card_list/horizontal_card_list.dart";
 import "../widgets/progress_bar.dart";
 
@@ -43,12 +46,19 @@ class ProfileView extends ConsumerWidget {
             ],
             const SizedBox(height: AppPaddings.medium),
             SectionHeader(context.l10n.achievements_statistics),
-            StatListWidget(stats: convertCompletedRoutesToStats(completedRoutes)),
+            StatListWidget<Stat>(stats: convertCompletedRoutesToStats(completedRoutes)),
             const SizedBox(height: AppPaddings.medium),
             if (kDebugMode) ...[
               SectionHeader(context.l10n.achievements_achievements),
               const SizedBox(height: AppPaddings.tinySmall),
-              StatListWidget(stats: mockAchievements),
+              StatListWidget<Achievement>(
+                stats: mockAchievements,
+                onTap:
+                    (stat) async => showDialog(
+                      context: context,
+                      builder: (context) => AchievementDescriptionModal(achievement: stat),
+                    ),
+              ),
             ],
           ],
         ),

--- a/lib/features/profile/widgets/achivement_description_modal.dart
+++ b/lib/features/profile/widgets/achivement_description_modal.dart
@@ -1,0 +1,28 @@
+import "package:flutter/material.dart";
+
+import "../../../app/config/ui_config.dart";
+import "../../../app/theme/app_theme.dart";
+import "../../../common/models/achievement.dart";
+import "../../../common/widgets/modals/info_modal.dart";
+
+class AchievementDescriptionModal extends StatelessWidget {
+  const AchievementDescriptionModal({super.key, required this.achievement});
+
+  final Achievement achievement;
+
+  @override
+  Widget build(BuildContext context) {
+    return InfoModal(
+      title: achievement.value,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        spacing: AppPaddings.small,
+        children: [
+          Icon(achievement.iconData, color: Color(achievement.iconColor), size: ProfileViewConfig.achievementsIconSize),
+          Text(achievement.description, style: context.textTheme.headlineSmall, textAlign: TextAlign.center),
+          const SizedBox(width: double.infinity),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/profile/widgets/horizontal_stat_card_list/card.dart
+++ b/lib/features/profile/widgets/horizontal_stat_card_list/card.dart
@@ -2,19 +2,21 @@ import "package:flutter/material.dart";
 
 import "../../../../app/config/ui_config.dart";
 import "../../../../app/theme/app_theme.dart";
-import "../../../../common/models/stats.dart";
+import "../../../../common/models/stat.dart";
 
 class StatCard extends StatelessWidget {
-  final Stats stat;
+  final Stat stat;
   final double width;
   final double height;
   final double iconSize;
+  final bool isValueText;
 
   const StatCard({
     required this.stat,
     this.iconSize = CardListConfig.iconSize,
     this.width = CardListConfig.itemWidth,
     this.height = CardListConfig.height,
+    this.isValueText = false,
     super.key,
   });
   @override
@@ -30,15 +32,13 @@ class StatCard extends StatelessWidget {
       ),
       child: Column(
         mainAxisSize: MainAxisSize.min,
-        mainAxisAlignment: MainAxisAlignment.center,
+        mainAxisAlignment: MainAxisAlignment.spaceAround,
         children: [
-          const Spacer(),
           Opacity(
             opacity: StatCardConfig.iconOpacity,
             child: Icon(stat.iconData, color: Color(stat.iconColor), size: iconSize),
           ),
-          const Spacer(),
-          Text(stat.value, style: context.textTheme.displayLarge),
+          Text(stat.value, style: isValueText ? context.textTheme.headlineSmall : context.textTheme.displayLarge),
         ],
       ),
     );

--- a/lib/features/profile/widgets/horizontal_stat_card_list/horizontal_card_list.dart
+++ b/lib/features/profile/widgets/horizontal_stat_card_list/horizontal_card_list.dart
@@ -1,15 +1,17 @@
 import "package:fast_immutable_collections/fast_immutable_collections.dart";
 import "package:flutter/material.dart";
 import "../../../../app/config/ui_config.dart";
-import "../../../../common/models/stats.dart";
+import "../../../../common/models/achievement.dart";
+import "../../../../common/models/stat.dart";
 import "card.dart";
 
-class StatListWidget extends StatelessWidget {
-  final IList<Stats> stats;
+class StatListWidget<T extends Stat> extends StatelessWidget {
+  final IList<T> stats;
   final double height;
   final double itemWidth;
   final double sideMargin;
   final double iconSize;
+  final void Function(T stat)? onTap;
 
   const StatListWidget({
     required this.stats,
@@ -17,6 +19,7 @@ class StatListWidget extends StatelessWidget {
     this.itemWidth = CardListConfig.itemWidth,
     this.sideMargin = AppPaddings.medium,
     this.iconSize = CardListConfig.iconSize,
+    this.onTap,
   });
 
   @override
@@ -32,7 +35,25 @@ class StatListWidget extends StatelessWidget {
           final stat = stats[index];
           return Padding(
             padding: const EdgeInsets.only(bottom: AppPaddings.nano),
-            child: StatCard(stat: stat, iconSize: iconSize, width: itemWidth, height: height),
+            child:
+                (onTap != null)
+                    ? GestureDetector(
+                      onTap: () => onTap!(stat),
+                      child: StatCard(
+                        stat: stat,
+                        iconSize: iconSize,
+                        width: itemWidth,
+                        height: height,
+                        isValueText: T == Achievement,
+                      ),
+                    )
+                    : StatCard(
+                      stat: stat,
+                      iconSize: iconSize,
+                      width: itemWidth,
+                      height: height,
+                      isValueText: T == Achievement,
+                    ),
           );
         },
       ),


### PR DESCRIPTION
<img width="411" height="833" alt="image" src="https://github.com/user-attachments/assets/f90ee6a0-dca4-4d6f-88d1-df0b91e24b8f" />
<img width="419" height="841" alt="image" src="https://github.com/user-attachments/assets/5d5b3a84-fdde-4ecb-81d3-e26cd434104c" />

hardcoded a list of few example achievements, adjusted the already existing horizontal stats list to accommodate the slightly different behaviour and look for the stats and achievements tiles.