### PR TITLE
refactor: improve layout and structure of RouteTile widget

### DIFF
--- a/lib/features/map/multi_route_map/widgets/select_route_bottom_sheet.dart
+++ b/lib/features/map/multi_route_map/widgets/select_route_bottom_sheet.dart
@@ -1,7 +1,9 @@
 import "dart:async";
+
 import "package:fast_immutable_collections/fast_immutable_collections.dart";
 import "package:flutter/material.dart" hide Route;
 import "package:flutter_riverpod/flutter_riverpod.dart";
+
 import "../../../../app/config/ui_config.dart";
 import "../../../../app/l10n/l10n.dart";
 import "../../../../app/theme/color_consts.dart";
@@ -9,6 +11,7 @@ import "../../../../common/models/route.dart";
 import "../../../../common/providers/bottom_sheet_providers.dart";
 import "../../../../common/widgets/buttons/main_action_button.dart";
 import "../../../../common/widgets/map_bottom_sheet.dart";
+import "../../route_map/providers/route_provider.dart";
 import "../../route_map/widgets/bottom_sheet/tiles/route_tile.dart";
 
 class SelectRouteBottomSheet extends ConsumerStatefulWidget {
@@ -51,7 +54,16 @@ class SelectRouteBottomSheetState extends ConsumerState<SelectRouteBottomSheet> 
           physics: const NeverScrollableScrollPhysics(),
           shrinkWrap: true,
           padding: EdgeInsets.zero,
-          separatorBuilder: (context, index) => const Divider(height: 1, thickness: 1, color: ColorConsts.mistGray),
+          separatorBuilder: (context, index) {
+            final expandedRoutes = ref.watch(expandedRoutesProvider);
+            final isAboveExpanded = expandedRoutes.any((r) => r.id == routes[index].id);
+            final isBelowExpanded =
+                (index + 1 < routes.length) && expandedRoutes.any((r) => r.id == routes[index + 1].id);
+
+            final isDark = isAboveExpanded || isBelowExpanded;
+
+            return Divider(height: 1, thickness: 1, color: isDark ? Colors.grey[800] : ColorConsts.mistGray);
+          },
           itemCount: routes.length,
           itemBuilder: (context, index) => RouteTile(route: routes[index]),
         ),

--- a/lib/features/map/route_map/widgets/bottom_sheet/tiles/route_tile.dart
+++ b/lib/features/map/route_map/widgets/bottom_sheet/tiles/route_tile.dart
@@ -48,68 +48,75 @@ class RouteTileState extends ConsumerState<RouteTile> {
   Widget build(BuildContext context) {
     final route = widget.route;
 
-    return ExpansionTile(
-      onExpansionChanged: (isExpanding) => updateExpandedRoutes(route, shouldDelete: !isExpanding),
-      title: Row(
-        spacing: AppPaddings.nano,
+    return Theme(
+      data: Theme.of(context).copyWith(dividerColor: Colors.transparent),
+
+      child: ExpansionTile(
+        onExpansionChanged: (isExpanding) => updateExpandedRoutes(route, shouldDelete: !isExpanding),
+        title: Row(
+          spacing: AppPaddings.nano,
+          children: [
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(route.name, style: context.textTheme.headlineSmall?.copyWith(fontSize: 22)),
+                  const SizedBox(height: 6),
+                  Text(route.distance.inKilometers()),
+                ],
+              ),
+            ),
+            RouteStat(
+              icon: Assets.icons.water.svg(width: SelectRouteConfig.iconSize, height: SelectRouteConfig.iconSize),
+              comment: (route.waterDemand ?? 0).inMilliliters(),
+            ),
+            if (route.estimatedTime != null)
+              RouteStat(
+                icon: Assets.icons.time.svg(width: SelectRouteConfig.iconSize, height: SelectRouteConfig.iconSize),
+                comment: route.estimatedTime!.inMinutes(),
+              ),
+            if (route.calories != null)
+              RouteStat(
+                icon: Assets.icons.kcal.svg(width: SelectRouteConfig.iconSize, height: SelectRouteConfig.iconSize),
+                comment: (route.calories ?? 0).inKcal(),
+              ),
+          ],
+        ),
         children: [
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(route.name, style: context.textTheme.headlineSmall?.copyWith(fontSize: 22)),
-                const SizedBox(height: 6),
-                Text(route.distance.inKilometers()),
-              ],
+          Padding(
+            padding: const EdgeInsets.all(AppPaddings.tinySmall),
+            child: SecondaryActionButton(
+              onPressed: () async {
+                await showDialog<StartRouteModal>(
+                  context: context,
+                  builder: (context) => StartRouteModal(route: route),
+                );
+              },
+              text: context.l10n.start_route,
             ),
           ),
-          RouteStat(
-            icon: Assets.icons.water.svg(width: SelectRouteConfig.iconSize, height: SelectRouteConfig.iconSize),
-            comment: (route.waterDemand ?? 0).inMilliliters(),
+          Padding(
+            padding: const EdgeInsets.all(AppPaddings.tinySmall),
+            child: SizedBox(
+              width: double.infinity,
+              child: RouteSegmentedButton(
+                chosenOption: _chosenOption,
+                onSelectionChanged: (newSelection) {
+                  updateExpandedRoutes(route);
+                  setState(() {
+                    _chosenOption = newSelection.first;
+                  });
+                },
+              ),
+            ),
           ),
-          if (route.estimatedTime != null)
-            RouteStat(
-              icon: Assets.icons.time.svg(width: SelectRouteConfig.iconSize, height: SelectRouteConfig.iconSize),
-              comment: route.estimatedTime!.inMinutes(),
-            ),
-          if (route.calories != null)
-            RouteStat(
-              icon: Assets.icons.kcal.svg(width: SelectRouteConfig.iconSize, height: SelectRouteConfig.iconSize),
-              comment: (route.calories ?? 0).inKcal(),
-            ),
+          const SizedBox(height: AppPaddings.small),
+          if (_chosenOption == RouteDetailsOption.info)
+            LandmarksSection(checkpoints: route.checkpoints)
+          else
+            PlaylistInfoSection(playlist: widget.route.playlist!),
         ],
       ),
-      children: [
-        Padding(
-          padding: const EdgeInsets.all(AppPaddings.tinySmall),
-          child: SecondaryActionButton(
-            onPressed: () async {
-              await showDialog<StartRouteModal>(context: context, builder: (context) => StartRouteModal(route: route));
-            },
-            text: context.l10n.start_route,
-          ),
-        ),
-        Padding(
-          padding: const EdgeInsets.all(AppPaddings.tinySmall),
-          child: SizedBox(
-            width: double.infinity,
-            child: RouteSegmentedButton(
-              chosenOption: _chosenOption,
-              onSelectionChanged: (newSelection) {
-                updateExpandedRoutes(route);
-                setState(() {
-                  _chosenOption = newSelection.first;
-                });
-              },
-            ),
-          ),
-        ),
-        const SizedBox(height: AppPaddings.small),
-        if (_chosenOption == RouteDetailsOption.info)
-          LandmarksSection(checkpoints: route.checkpoints)
-        else
-          PlaylistInfoSection(playlist: widget.route.playlist!),
-      ],
     );
   }
 }


### PR DESCRIPTION
Replace ExpansionTile divider with new ListView separator logic.

<img width="439" height="928" alt="Android Emulator - Pixel_6_5554 10 09 2025 17_35_47" src="https://github.com/user-attachments/assets/a6586a88-07fa-4b59-85f8-274641ada627" />

<img width="439" height="928" alt="Android Emulator - Pixel_6_5554 10 09 2025 17_35_57" src="https://github.com/user-attachments/assets/5442c066-3633-432d-8465-f1336269ed66" />
<img width="439" height="928" alt="Android Emulator - Pixel_6_5554 10 09 2025 17_36_05" src="https://github.com/user-attachments/assets/82f9118b-1d12-48a9-ab7f-81455bb03e44" />
