### PR TITLE
fix: popup on small screens

### DIFF
--- a/lib/app/config/ui_config.dart
+++ b/lib/app/config/ui_config.dart
@@ -108,6 +108,8 @@ abstract class OptionsModalConfig {
   static const largeOuterPaddingVertical = 155.0;
   static const mediumOuterPaddingVertical = 105.0;
   static const smallOuterPaddingVertical = 55.0;
+  static const smallThresh = 620.0;
+  static const mediumThresh = 920.0;
   static const titleSpacer = 6.0;
 }
 
@@ -129,6 +131,7 @@ abstract class RouteCompleteModalConfig {
   static const verticalSpacing = 16.0;
   static const horizontalSpacing = 26.0;
   static const decorationSize = 120.0;
+  static const widthThresh = 420.0;
 }
 
 abstract final class MapConfig {

--- a/lib/app/config/ui_config.dart
+++ b/lib/app/config/ui_config.dart
@@ -105,7 +105,9 @@ abstract class InfoModalConfig {
 
 abstract class OptionsModalConfig {
   static const radius = 15.0;
-  static const outerPaddingVertical = 195.0;
+  static const largeOuterPaddingVertical = 155.0;
+  static const mediumOuterPaddingVertical = 105.0;
+  static const smallOuterPaddingVertical = 55.0;
   static const titleSpacer = 6.0;
 }
 

--- a/lib/app/l10n/arb/app_pl.arb
+++ b/lib/app/l10n/arb/app_pl.arb
@@ -18,6 +18,7 @@
 
   "stats": "Statystyki",
   "achievements": "Zdobyte Osiągnięcia",
+  "distance": "Odległość",
   "covered_distance": "Przebyta odległość",
   "burnt_calories": "Spalone kalorie",
   "time": "Czas",

--- a/lib/common/widgets/modals/options_modal.dart
+++ b/lib/common/widgets/modals/options_modal.dart
@@ -23,9 +23,9 @@ class OptionsModal extends StatelessWidget {
       insetPadding: EdgeInsets.symmetric(
         horizontal: AppPaddings.medium,
         vertical:
-            MediaQuery.sizeOf(context).height > 920
+            MediaQuery.sizeOf(context).height > OptionsModalConfig.mediumThresh
                 ? OptionsModalConfig.largeOuterPaddingVertical
-                : MediaQuery.sizeOf(context).height > 620
+                : MediaQuery.sizeOf(context).height > OptionsModalConfig.smallThresh
                 ? OptionsModalConfig.mediumOuterPaddingVertical
                 : OptionsModalConfig.smallOuterPaddingVertical,
       ),

--- a/lib/common/widgets/modals/options_modal.dart
+++ b/lib/common/widgets/modals/options_modal.dart
@@ -20,9 +20,14 @@ class OptionsModal extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Dialog(
-      insetPadding: const EdgeInsets.symmetric(
+      insetPadding: EdgeInsets.symmetric(
         horizontal: AppPaddings.medium,
-        vertical: OptionsModalConfig.outerPaddingVertical,
+        vertical:
+            MediaQuery.sizeOf(context).height > 920
+                ? OptionsModalConfig.largeOuterPaddingVertical
+                : MediaQuery.sizeOf(context).height > 620
+                ? OptionsModalConfig.mediumOuterPaddingVertical
+                : OptionsModalConfig.smallOuterPaddingVertical,
       ),
       backgroundColor: context.colorScheme.surface,
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(OptionsModalConfig.radius)),

--- a/lib/features/debug_playground/debug_playground.dart
+++ b/lib/features/debug_playground/debug_playground.dart
@@ -2,9 +2,11 @@ import "package:flutter/material.dart";
 import "package:flutter_riverpod/flutter_riverpod.dart";
 
 import "../../app/app.dart";
+import "../../common/data_source/mocks/mock_routes.dart";
 import "../../common/models/completed_route.dart";
 import "../../common/providers/completed_routes_provider.dart";
 import "../map/route_map/controllers/route_controller.dart";
+import "../map/route_map/modals/route_completed_modal.dart";
 import "../map/route_map/repository/route_map_repository.dart";
 import "widgets/shimmer_test_widget.dart";
 
@@ -21,6 +23,16 @@ class DebugPlayground extends StatelessWidget {
           mainAxisAlignment: MainAxisAlignment.center,
           children: <Widget>[
             OutlinedButton(onPressed: () async => context.router.pushMultiRouteMap(), child: const Text("RouteMap")),
+            OutlinedButton(
+              onPressed:
+                  () async => showDialog(
+                    context: context,
+                    builder:
+                        (context) =>
+                            RouteCompletedModal(route: mockData[0], time: const Duration(hours: 2, minutes: 3)),
+                  ),
+              child: const Text("Show modal"),
+            ),
             OutlinedButton(
               onPressed: () async => context.router.pushRouteMap(71),
               child: const Text("RouteMap with route"),

--- a/lib/features/map/route_map/modals/route_completed_modal.dart
+++ b/lib/features/map/route_map/modals/route_completed_modal.dart
@@ -48,7 +48,7 @@ class RouteCompletedModal extends StatelessWidget {
             children: [
               Expanded(
                 child: StatInfoCompact(
-                  title: context.l10n.covered_distance,
+                  title: MediaQuery.sizeOf(context).width > 420 ? context.l10n.covered_distance : context.l10n.distance,
                   value: route.distance.inKilometers(),
                   icon: Icons.social_distance_outlined,
                   color: RouteCompleteModalConfig.distanceInfoColor,

--- a/lib/features/map/route_map/modals/route_completed_modal.dart
+++ b/lib/features/map/route_map/modals/route_completed_modal.dart
@@ -48,7 +48,10 @@ class RouteCompletedModal extends StatelessWidget {
             children: [
               Expanded(
                 child: StatInfoCompact(
-                  title: MediaQuery.sizeOf(context).width > 420 ? context.l10n.covered_distance : context.l10n.distance,
+                  title:
+                      MediaQuery.sizeOf(context).width > RouteCompleteModalConfig.widthThresh
+                          ? context.l10n.covered_distance
+                          : context.l10n.distance,
                   value: route.distance.inKilometers(),
                   icon: Icons.social_distance_outlined,
                   color: RouteCompleteModalConfig.distanceInfoColor,


### PR DESCRIPTION
In the slim screens, changed the text from Przebyta odległość to just Odległość, additionally, added 3 options for padding size depending on the screen height. Preview from emulator with a small screen as well as secondary screens in basic emulator
<img width="424" height="854" alt="image" src="https://github.com/user-attachments/assets/542082a5-70da-4be9-9953-db7d77395fc7" />
<img width="421" height="747" alt="image" src="https://github.com/user-attachments/assets/6fd37412-2aeb-4f89-83d3-6c5fca33a57c" />
<img width="209" height="505" alt="image" src="https://github.com/user-attachments/assets/e14f3d82-2339-4869-a930-72b70a04c1c3" />
