### PR TITLE
fix: current location indicator layer

### DIFF
--- a/lib/app/config/ui_config.dart
+++ b/lib/app/config/ui_config.dart
@@ -159,6 +159,7 @@ abstract final class LocalizationConfig {
   static const didWalkAwayThresholdInMeters = 70.0;
   static const blockLastThreshouldInMeters = 70.0;
   static const distanceChangeFilter = 3;
+  static const currentLocalizationSize = Size(22, 22);
 }
 
 abstract final class StatInfoCompactConfig {

--- a/lib/features/map/multi_route_map/widgets/multi_route_map_widget.dart
+++ b/lib/features/map/multi_route_map/widgets/multi_route_map_widget.dart
@@ -1,6 +1,7 @@
 import "package:fast_immutable_collections/fast_immutable_collections.dart";
 import "package:flutter/material.dart";
 import "package:flutter_map/flutter_map.dart";
+import "package:flutter_map_location_marker/flutter_map_location_marker.dart";
 import "package:flutter_riverpod/flutter_riverpod.dart";
 
 import "../../../../app/config/flutter_map_config.dart";
@@ -46,6 +47,14 @@ class _MultiRouteMapWidgetState extends ConsumerState<MultiRouteMapWidget> {
               selectedColor: context.colorScheme.primary,
               notSelectedColor: MapConfig.unvisitedColor,
             ),
+          const CurrentLocationLayer(
+            style: LocationMarkerStyle(
+              marker: DefaultLocationMarker(color: Colors.blue),
+              markerSize: LocalizationConfig.currentLocalizationSize,
+              accuracyCircleColor: Color(0x2288B4EA),
+              headingSectorColor: Color(0x4488B4EA),
+            ),
+          ),
         ],
       ),
       _ => const Center(child: CircularProgressIndicator()),

--- a/lib/features/map/route_map/widgets/map/route_map_widget.dart
+++ b/lib/features/map/route_map/widgets/map/route_map_widget.dart
@@ -70,14 +70,6 @@ class RouteMapWidgetState extends ConsumerState<RouteMapWidget> with WidgetsBind
             active: widget.active,
             passedLocations: passedLocations,
           ),
-          const CurrentLocationLayer(
-            style: LocationMarkerStyle(
-              marker: DefaultLocationMarker(color: Colors.blue),
-              markerSize: Size(28, 28),
-              accuracyCircleColor: Color(0x2288B4EA),
-              headingSectorColor: Color(0x4488B4EA),
-            ),
-          ),
           MarkerLayer(
             markers:
                 landmarks.asMap().entries.map((entry) {
@@ -99,6 +91,14 @@ class RouteMapWidgetState extends ConsumerState<RouteMapWidget> with WidgetsBind
                     markerAlignment: alignment,
                   );
                 }).toList(),
+          ),
+          const CurrentLocationLayer(
+            style: LocationMarkerStyle(
+              marker: DefaultLocationMarker(color: Colors.blue),
+              markerSize: LocalizationConfig.currentLocalizationSize,
+              accuracyCircleColor: Color(0x2288B4EA),
+              headingSectorColor: Color(0x4488B4EA),
+            ),
           ),
         ],
       ),


### PR DESCRIPTION
# Changes

1) add current location indicator for multi-route view
<img width="200" height="779" alt="image" src="https://github.com/user-attachments/assets/5068050d-d899-4bff-9256-82c46da12dc9" />
<img width="200" height="784" alt="image" src="https://github.com/user-attachments/assets/2067be4e-9ec2-4591-a7fe-4e0cfd1de795" />

2) move current location indicator to top layer (on top of checkpoints)
<img width="200" height="777" alt="image" src="https://github.com/user-attachments/assets/cef894cb-6d88-46fd-91aa-1314f94d75f3" />
<img width="200" height="782" alt="image" src="https://github.com/user-attachments/assets/392449a5-1c37-4748-9f0f-d0b61a7377d4" />
<img width="200" height="780" alt="image" src="https://github.com/user-attachments/assets/8942185f-6811-4c25-b057-da14470119a9" />
<img width="200" height="782" alt="image" src="https://github.com/user-attachments/assets/2d3ae27d-171a-43b5-9390-69b268fe0212" />

Please not that the current location indicator is a bit smaller because the big one looked weird (I chose the most natural one)